### PR TITLE
Bfloat16 to float32 to avoid issues with numpy

### DIFF
--- a/colpali_engine/interpretability/gen_interpretability_plots.py
+++ b/colpali_engine/interpretability/gen_interpretability_plots.py
@@ -86,6 +86,7 @@ def generate_interpretability_plots(
     attention_map_normalized = normalize_attention_map_per_query_token(
         attention_map
     )  # (1, n_text_tokens, n_patch_x, n_patch_y)
+    attention_map_normalized = attention_map_normalized.float()
 
     # Get text token information
     n_tokens = input_text_processed.input_ids.size(1)


### PR DESCRIPTION
As described  in https://github.com/illuin-tech/colpali/issues/3

`attention_map_normalized` is a torch `Bfloat16`. Converting to `float32` fixes possible issues when calling `numpy()`.