### PR TITLE
Fix installation instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install git+https://github.com/illuin-tech/colpali
 ### From source
 ```bash
 git clone https://github.com/illuin-tech/colpali
-mv colpali
+cd colpali
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Replaced `mv` with `cd` in the `README.md` file to correctly navigate to the cloned repository directory.