### PR TITLE
Fix edge case when empty suffix "" given to processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+
+- Fix edge case when empty suffix `""` given to processor
+
 ## [0.3.0] - 2024-09-10
 
 ✨ This release is an exhaustive package refacto, making ColPali more modular and easier to use.

--- a/colpali_engine/models/paligemma/colpali/processing_colpali.py
+++ b/colpali_engine/models/paligemma/colpali/processing_colpali.py
@@ -43,9 +43,8 @@ class ColPaliProcessor(BaseVisualRetrieverProcessor, PaliGemmaProcessor):
         """
         Process queries for ColPali.
         """
-        # NOTE: The image is required for calling PaligemmaProcessor, so we create a mock image here.
-
-        suffix = suffix or "<pad>" * 10
+        if suffix is None:
+            suffix = "<pad>" * 10
         texts_query: List[str] = []
 
         for query in queries:


### PR DESCRIPTION
## Description

```
>>> suffix = ""
>>> suffix = suffix or "<pad>" * 10
>>> suffix
'<pad><pad><pad><pad><pad><pad><pad><pad><pad><pad>'
```

while we want to allow the user to choose not to use a suffix in `ColPaliProcessor.process_queries`.