### PR TITLE
Support Qwen2VL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add module-level imports for collators
 - Add sanity check in the run inference example script
 - Add E2E test for ColPali
+- Add Qwen2-VL support
 
 ### Changed
 
 - Improve code clarity the run inference example script
 - Subset the example dataset in the run inference example script
 - Rename scorer test to `test_processing_utils`
+- Greatly simplify routing logic in Trainer selection and when feeding arguments to the model forward pass (refacto)
+- Bumped transformers version to 4.45.0 to get Qwen2-VL support
 
 ### Fixed
 
 - Import HardNegCollator at module-level if and only if datasets is available
 - Remove the need for `typer` in the run inference example script
 - Fix edge case when empty suffix `""` given to processor
+- Fix bug in HardNegCollator since 0.3.0
 
 ## [0.3.0] - 2024-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Subset the example dataset in the run inference example script
 - Rename scorer test to `test_processing_utils`
 - Greatly simplify routing logic in Trainer selection and when feeding arguments to the model forward pass (refacto)
+- Removed class `ContrastiveNegativeTrainer` which is now just integrated in ContrastiveTrainer. This should not affect the user-facing API.
 - Bumped transformers version to 4.45.0 to get Qwen2-VL support
 
 ### Fixed

--- a/colpali_engine/collators/hard_neg_collator.py
+++ b/colpali_engine/collators/hard_neg_collator.py
@@ -40,4 +40,4 @@ class HardNegCollator(VisualRetrieverCollator):
 
             examples += [{"image": pos_image, "query": pos_query, "neg_image": neg_image}]
 
-        return self(examples)
+        return super().__call__(examples)

--- a/colpali_engine/collators/visual_retriever_collator.py
+++ b/colpali_engine/collators/visual_retriever_collator.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, List, Union, cast
 
 from PIL.Image import Image
 
-from colpali_engine.models.paligemma import ColPaliProcessor
 from colpali_engine.models.idefics_2 import ColIdefics2Processor
+from colpali_engine.models.paligemma import ColPaliProcessor
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
 
 

--- a/colpali_engine/collators/visual_retriever_collator.py
+++ b/colpali_engine/collators/visual_retriever_collator.py
@@ -78,7 +78,8 @@ class VisualRetrieverCollator:
         batch_query = None
 
         if all([t is None for t in texts_query]):
-            print("All queries are `None`. Returning `None` for all queries.")
+            # print("All queries are `None`. Returning `None` for all queries.")
+            pass
         elif any([t is None for t in texts_query]):
             # If it's the first query that is not None but the rest are None, then it's hard negatives.
             raise ValueError("Some queries are None. This collator does not support None queries yet.")

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -22,9 +22,9 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
-        inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
-        outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
-        # outputs = super().forward(*args, **kwargs, output_hidden_states=True)
+        # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
+        # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
+        outputs = super().forward(*args, **kwargs, output_hidden_states=True)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -17,7 +17,7 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
         self.padding_side = "right"
-        self.config.rope_scaling["mrope_section"] = [
+        self.rope_scaling["mrope_section"] = [
             16,
             24,
             24

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -16,13 +16,15 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         super().__init__(config=config)
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
+        self.padding_side = "right"
         self.post_init()
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
-        inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
-        outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
+        # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
+        # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
+        outputs = super().forward(*args, **kwargs, output_hidden_states=True)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -14,11 +14,8 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
 
     def __init__(self, config: Qwen2VLConfig):
         super().__init__(config=config)
-
-        # TODO: verify weight tying and that type of things
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
-
         self.post_init()
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
@@ -30,7 +27,5 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
 
         # L2 normalization
         proj = proj / proj.norm(dim=-1, keepdim=True)  # (batch_size, sequence_length, dim)
-
         proj = proj * kwargs["attention_mask"].unsqueeze(-1)  # (batch_size, sequence_length, dim)
-
         return proj

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -21,7 +21,8 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
-        outputs = super().forward(*args, output_hidden_states=True, **kwargs)  # (batch_size, sequence_length, hidden_size)
+        inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
+        outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -22,9 +22,9 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
-        # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
-        # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
-        outputs = super().forward(*args, **kwargs, output_hidden_states=True)
+        inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
+        outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
+        # outputs = super().forward(*args, **kwargs, output_hidden_states=True)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -5,7 +5,7 @@ from torch import nn
 from transformers.models.qwen2_vl import Qwen2VLConfig, Qwen2VLForConditionalGeneration, Qwen2VLPreTrainedModel
 
 
-class ColQwen2(Qwen2VLPreTrainedModel):
+class ColQwen2(Qwen2VLForConditionalGeneration):
     """
     ColQwen2 model implementation from the "ColPali: Efficient Document Retrieval with Vision Language Models" paper.
     """
@@ -15,8 +15,7 @@ class ColQwen2(Qwen2VLPreTrainedModel):
     def __init__(self, config: Qwen2VLConfig):
         super().__init__(config=config)
 
-        self.model = Qwen2VLForConditionalGeneration(config=config)
-        # TODO:  verify weight tying
+        # TODO: verify weight tying and that type of things
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
 
@@ -25,7 +24,7 @@ class ColQwen2(Qwen2VLPreTrainedModel):
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
-        outputs = self.model(*args, output_hidden_states=True, **kwargs)  # (batch_size, sequence_length, hidden_size)
+        outputs = super().forward(*args, output_hidden_states=True, **kwargs)  # (batch_size, sequence_length, hidden_size)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -17,6 +17,11 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
         self.padding_side = "right"
+        self.config.rope_scaling["mrope_section"] = [
+            16,
+            24,
+            24
+        ]
         self.post_init()
 
     def forward(self, *args, **kwargs) -> torch.Tensor:

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -29,9 +29,11 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         if "pixel_values" in kwargs:
             print(f"pixel_values shape: {kwargs['pixel_values'].shape}")
 
-        # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
-        # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
-        outputs = super().forward(*args, **kwargs, output_hidden_states=True)
+        inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
+        print(inputs.keys())
+        outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
+
+        # outputs = super().forward(*args, **kwargs, output_hidden_states=True)
         last_hidden_states = outputs.hidden_states[-1]  # (batch_size, sequence_length, hidden_size)
         proj = self.custom_text_proj(last_hidden_states)  # (batch_size, sequence_length, dim)
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -39,8 +39,9 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
             # for pv, o in zip(kwargs["pixel_values"], offsets):
             #     new_pixel_values.append(pv[:o])
 
+            breakpoint()
             kwargs["pixel_values"] = torch.cat([pv[:o] for pv, o in zip(kwargs["pixel_values"], offsets)], dim=0)
-            print(kwargs["pixel_values"].shape)
+            # print(kwargs["pixel_values"].shape)
 
         inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
         # print(inputs.keys())

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -33,13 +33,13 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         if "pixel_values" in kwargs:
             # compute pixel_values offsets
             offsets = kwargs["image_grid_thw"][:, 1] * kwargs["image_grid_thw"][:, 2]
-            print(offsets)
+            # print(offsets)
             # iterate over the pixel_values and keep only their offset
             new_pixel_values = []
             for pv, o in zip(kwargs["pixel_values"], offsets):
                 new_pixel_values.append(pv[:o])
             kwargs["pixel_values"] = torch.cat(new_pixel_values)
-            print(kwargs["pixel_values"].shape)
+            # print(kwargs["pixel_values"].shape)
 
         inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
         # print(inputs.keys())

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -2,7 +2,7 @@ from typing import ClassVar
 
 import torch
 from torch import nn
-from transformers.models.qwen2_vl import Qwen2VLConfig, Qwen2VLForConditionalGeneration, Qwen2VLPreTrainedModel
+from transformers.models.qwen2_vl import Qwen2VLConfig, Qwen2VLForConditionalGeneration
 
 
 class ColQwen2(Qwen2VLForConditionalGeneration):

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -16,7 +16,7 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         super().__init__(config=config)
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
-        self.padding_side = "right"
+        self.padding_side = "left"
         self.post_init()
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
@@ -24,13 +24,13 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         kwargs.pop("output_hidden_states", None)
         # from kwargs, get the pixel_value shape and input_ids shape
 
-        print(f"input_ids shape: {kwargs['input_ids'].shape}")
-
-        if "pixel_values" in kwargs:
-            print(f"pixel_values shape: {kwargs['pixel_values'].shape}")
+        # print(f"input_ids shape: {kwargs['input_ids'].shape}")
+        #
+        # if "pixel_values" in kwargs:
+        #     print(f"pixel_values shape: {kwargs['pixel_values'].shape}")
 
         inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
-        print(inputs.keys())
+        # print(inputs.keys())
         outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
 
         # outputs = super().forward(*args, **kwargs, output_hidden_states=True)

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -29,6 +29,18 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         # if "pixel_values" in kwargs:
         #     print(f"pixel_values shape: {kwargs['pixel_values'].shape}")
 
+        # reverse the operation with pixel_values for scatter
+        if "pixel_values" in kwargs:
+            # compute pixel_values offsets
+            offsets = kwargs["image_grid_thw"][:, 1] * kwargs["image_grid_thw"][:, 2]
+            print(offsets)
+            # iterate over the pixel_values and keep only their offset
+            new_pixel_values = []
+            for pv, o in zip(kwargs["pixel_values"], offsets):
+                new_pixel_values.append(pv[:o])
+            kwargs["pixel_values"] = torch.cat(new_pixel_values)
+            print(kwargs["pixel_values"].shape)
+
         inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
         # print(inputs.keys())
         outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -17,11 +17,6 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         self.dim = 128
         self.custom_text_proj = nn.Linear(self.model.config.hidden_size, self.dim)
         self.padding_side = "right"
-        self.rope_scaling["mrope_section"] = [
-            16,
-            24,
-            24
-        ]
         self.post_init()
 
     def forward(self, *args, **kwargs) -> torch.Tensor:

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -22,6 +22,10 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
     def forward(self, *args, **kwargs) -> torch.Tensor:
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
+        # from kwargs, get the pixel_value shape and input_ids shape
+        print(f"pixel values shape: {kwargs['pixel_values'].shape}")
+        print(f"input_ids shape: {kwargs['input_ids'].shape}")
+
         # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
         # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)
         outputs = super().forward(*args, **kwargs, output_hidden_states=True)

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -23,8 +23,11 @@ class ColQwen2(Qwen2VLForConditionalGeneration):
         # Delete output_hidden_states from kwargs
         kwargs.pop("output_hidden_states", None)
         # from kwargs, get the pixel_value shape and input_ids shape
-        print(f"pixel values shape: {kwargs['pixel_values'].shape}")
+
         print(f"input_ids shape: {kwargs['input_ids'].shape}")
+
+        if "pixel_values" in kwargs:
+            print(f"pixel_values shape: {kwargs['pixel_values'].shape}")
 
         # inputs = self.prepare_inputs_for_generation(*args, **kwargs, use_cache=False)
         # outputs = super().forward(**inputs, output_hidden_states=True)  # (batch_size, sequence_length, hidden_size)

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -36,7 +36,9 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
             resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
             return image.convert("RGB").resize((resized_width, resized_height))
 
-        images = [resize_and_convert(image) for image in images]
+        # images = [resize_and_convert(image) for image in images]
+
+        images = [image.convert("RGB").resize((896, 896)) for image in images]
 
         batch_doc = self(
             text=texts_doc,
@@ -61,7 +63,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         texts_query: List[str] = []
 
         for query in queries:
-            query = f"Question: {query}"
+            query = f"Query: {query}"
             query += suffix  # add suffix (pad tokens)
             texts_query.append(query)
 

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -7,6 +7,7 @@ from transformers.models.qwen2_vl import Qwen2VLProcessor
 
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
 
+from qwen_vl_utils import smart_resize
 
 class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
     """
@@ -16,6 +17,9 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.tokenizer.padding_side = "right"
+        self.min_pixels =  3136 # 4 * 28 * 28
+        self.max_pixels =  802816 # 1024 * 28 * 28
+        self.factor = 28
 
     def process_images(
         self,
@@ -27,9 +31,12 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         texts_doc = (["<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe the image.<|im_end|>\n"]
                      * len(images))
 
-        # TODO: figure out best option for resizing images
-        # images = [image.convert("RGB") for image in images]
-        images = [image.convert("RGB").resize((448, 448)) for image in images]
+        def resize_and_convert(image):
+            image_size = image.size
+            resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
+            return image.convert("RGB").resize((resized_width, resized_height))
+
+        images = [resize_and_convert(image) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -38,7 +38,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
 
         # images = [resize_and_convert(image) for image in images]
 
-        images = [image.convert("RGB").resize((896, 896)) for image in images]
+        images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -15,6 +15,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.tokenizer.padding_side = "right"
 
     def process_images(
         self,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -17,8 +17,8 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.tokenizer.padding_side = "right"
-        self.min_pixels =  3136 # 4 * 28 * 28
-        self.max_pixels =  802816 # 1024 * 28 * 28
+        self.min_pixels =  4 * 28 * 28
+        self.max_pixels =  512 * 28 * 28
         self.factor = 28
 
     def process_images(
@@ -36,9 +36,9 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
             resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
             return image.convert("RGB").resize((resized_width, resized_height))
 
-        # images = [resize_and_convert(image) for image in images]
+        images = [resize_and_convert(image) for image in images]
 
-        images = [image.convert("RGB").resize((448, 448)) for image in images]
+        # images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -2,12 +2,12 @@ from typing import List, Optional, Union
 
 import torch
 from PIL import Image
+from qwen_vl_utils import smart_resize
 from transformers import BatchFeature
 from transformers.models.qwen2_vl import Qwen2VLProcessor
 
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
 
-from qwen_vl_utils import smart_resize
 
 class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
     """
@@ -33,7 +33,11 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
 
         def resize_and_convert(image):
             image_size = image.size
-            resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
+            resized_height, resized_width = smart_resize(image_size[1],
+                                                         image_size[0],
+                                                         factor=self.factor,
+                                                         min_pixels=self.min_pixels,
+                                                         max_pixels=self.max_pixels)
             # print(f"Resizing image from {image_size} to {(resized_height, resized_width)}")
             return image.convert("RGB").resize((resized_width, resized_height))
 
@@ -50,13 +54,13 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
 
         # The following code is a hack to make sure the scatter in DDP is done correctly when training on multiple GPUs
         offsets = batch_doc["image_grid_thw"][:, 1] * batch_doc["image_grid_thw"][:, 2]
-        # print(offsets)
         # separate pixel_values for each image
-        # print(batch_doc["pixel_values"].shape)
         pixel_values = torch.split(batch_doc["pixel_values"], offsets.tolist())
         # pad pixel_values to the same length to be able to make it into a tensor
         max_length = max([len(pv) for pv in pixel_values])
-        pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
+        pixel_values = [torch.cat([pv,
+                                   torch.zeros((max_length - len(pv), pv.shape[1]),
+                                               dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
         batch_doc["pixel_values"] = torch.stack(pixel_values)
 
         return batch_doc

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -18,7 +18,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         super().__init__(*args, **kwargs)
         self.tokenizer.padding_side = "left"
         self.min_pixels =  4 * 28 * 28
-        self.max_pixels =  512 * 28 * 28
+        self.max_pixels =  1024 * 28 * 28
         self.factor = 28
 
     def process_images(

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -16,9 +16,6 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.min_pixels = 256 * 28 * 28
-        self.max_pixels = 256 * 28 * 28     # 1280
-
     def process_images(
         self,
         images: List[Image.Image],
@@ -28,6 +25,8 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         """
         texts_doc = (["<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe the image.<|im_end|>\n"]
                      * len(images))
+
+        # TODO: figure out best option for resizing images
         images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -27,7 +27,8 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
                      * len(images))
 
         # TODO: figure out best option for resizing images
-        images = [image.convert("RGB").resize((448, 448)) for image in images]
+        images = [image.convert("RGB") for image in images]
+        # images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -52,7 +52,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         offsets = batch_doc["image_grid_thw"][:, 1] * batch_doc["image_grid_thw"][:, 2]
         # print(offsets)
         # separate pixel_values for each image
-        print(batch_doc["pixel_values"].shape)
+        # print(batch_doc["pixel_values"].shape)
         pixel_values = torch.split(batch_doc["pixel_values"], offsets.tolist())
         # pad pixel_values to the same length to be able to make it into a tensor
         max_length = max([len(pv) for pv in pixel_values])

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -27,8 +27,8 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
                      * len(images))
 
         # TODO: figure out best option for resizing images
-        images = [image.convert("RGB") for image in images]
-        # images = [image.convert("RGB").resize((448, 448)) for image in images]
+        # images = [image.convert("RGB") for image in images]
+        images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -18,7 +18,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         super().__init__(*args, **kwargs)
         self.tokenizer.padding_side = "left"
         self.min_pixels =  4 * 28 * 28
-        self.max_pixels =  1024 * 28 * 28
+        self.max_pixels =  512 * 28 * 28
         self.factor = 28
 
     def process_images(

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -36,9 +36,9 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
             resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
             return image.convert("RGB").resize((resized_width, resized_height))
 
-        images = [resize_and_convert(image) for image in images]
+        # images = [resize_and_convert(image) for image in images]
 
-        # images = [image.convert("RGB").resize((448, 448)) for image in images]
+        images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -34,11 +34,12 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         def resize_and_convert(image):
             image_size = image.size
             resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
+            print(f"Resizing image from {image_size} to {(resized_height, resized_width)}")
             return image.convert("RGB").resize((resized_width, resized_height))
 
-        # images = [resize_and_convert(image) for image in images]
+        images = [resize_and_convert(image) for image in images]
 
-        images = [image.convert("RGB").resize((448, 448)) for image in images]
+        # images = [image.convert("RGB").resize((448, 448)) for image in images]
 
         batch_doc = self(
             text=texts_doc,

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -63,6 +63,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
                                                dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
         batch_doc["pixel_values"] = torch.stack(pixel_values)
 
+
         return batch_doc
 
     def process_queries(

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -75,7 +75,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         texts_doc = (["<|im_start|>user\n<|vision_start|><|image_pad|><|vision_end|>Describe the image.<|im_end|>\n"]
                      * len(images))
 
-        def resize_and_convert(image):
+        def resize_and_convert(image: Image.Image) -> Image.Image:
             image_size = image.size
             resized_height, resized_width = self.smart_resize(image_size[1],
                                                          image_size[0],

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -16,7 +16,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.tokenizer.padding_side = "right"
+        self.tokenizer.padding_side = "left"
         self.min_pixels =  4 * 28 * 28
         self.max_pixels =  512 * 28 * 28
         self.factor = 28

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -34,7 +34,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         def resize_and_convert(image):
             image_size = image.size
             resized_height, resized_width = smart_resize(image_size[1], image_size[0], factor=self.factor, min_pixels=self.min_pixels, max_pixels=self.max_pixels)
-            print(f"Resizing image from {image_size} to {(resized_height, resized_width)}")
+            # print(f"Resizing image from {image_size} to {(resized_height, resized_width)}")
             return image.convert("RGB").resize((resized_width, resized_height))
 
         images = [resize_and_convert(image) for image in images]

--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -18,7 +18,7 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         super().__init__(*args, **kwargs)
         self.tokenizer.padding_side = "left"
         self.min_pixels =  4 * 28 * 28
-        self.max_pixels =  512 * 28 * 28
+        self.max_pixels =  768 * 28 * 28
         self.factor = 28
 
     def process_images(

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -67,6 +67,8 @@ class ColModelTrainingConfig:
 
         if self.pretrained_peft_model_name_or_path is not None:
             self.model.load_adapter(self.pretrained_peft_model_name_or_path)
+            self.model.inference_mode = False
+
             print(f"Loaded pretrained adapter from {self.pretrained_peft_model_name_or_path}")
 
         if self.peft_config is not None:

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -185,6 +185,8 @@ class ColModelTraining:
             for dataloader in [dataloader_with_query, dataloader_without_query]:
                 for batch in tqdm(dataloader):
                     doc = self.model(**{k[4:]: v.to(device) for k, v in batch.items() if k.startswith("doc")})
+                    # Example for key="doc_input_ids":
+                    # `doc = self.model(input_ids=batch["doc_input_ids"].to(device))`
 
                     ps.extend(list(torch.unbind(doc.to("cpu"))))
 

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -67,7 +67,6 @@ class ColModelTrainingConfig:
 
         if self.pretrained_peft_model_name_or_path is not None:
             self.model.load_adapter(self.pretrained_peft_model_name_or_path)
-            self.model.inference_mode = False
 
             print(f"Loaded pretrained adapter from {self.pretrained_peft_model_name_or_path}")
 

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -106,7 +106,6 @@ class ColModelTraining:
             self.dataset = self.dataset[0]
             self.collator = HardNegCollator(
                 processor=self.config.processor,
-                tokenizer=self.config.tokenizer,
                 max_length=self.config.max_length,
                 image_dataset=neg_dataset,
             )

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -20,7 +20,7 @@ from colpali_engine.collators.visual_retriever_collator import VisualRetrieverCo
 from colpali_engine.loss.late_interaction_losses import (
     ColbertLoss,
 )
-from colpali_engine.trainer.contrastive_trainer import ContrastiveNegativeTrainer, ContrastiveTrainer
+from colpali_engine.trainer.contrastive_trainer import ContrastiveTrainer
 from colpali_engine.trainer.eval_utils import CustomRetrievalEvaluator
 from colpali_engine.utils.gpu_stats import print_gpu_utilization, print_summary
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
@@ -120,26 +120,19 @@ class ColModelTraining:
     def train(self) -> None:
         if isinstance(self.collator, HardNegCollator):
             print("Training with hard negatives")
-            trainer = ContrastiveNegativeTrainer(
-                model=self.model,
-                train_dataset=self.dataset["train"],
-                eval_dataset=self.dataset["test"],
-                args=self.config.tr_args,
-                data_collator=self.collator,
-                loss_func=self.config.loss_func,
-                is_vision_model=self.config.processor is not None,
-            )
         else:
             print("Training with in-batch negatives")
-            trainer = ContrastiveTrainer(
-                model=self.model,
-                train_dataset=self.dataset["train"],
-                eval_dataset=self.dataset["test"],
-                args=self.config.tr_args,
-                data_collator=self.collator,
-                loss_func=self.config.loss_func,
-                is_vision_model=self.config.processor is not None,
-            )
+
+        trainer = ContrastiveTrainer(
+            model=self.model,
+            train_dataset=self.dataset["train"],
+            eval_dataset=self.dataset["test"],
+            args=self.config.tr_args,
+            data_collator=self.collator,
+            loss_func=self.config.loss_func,
+            is_vision_model=self.config.processor is not None,
+        )
+
         trainer.args.remove_unused_columns = False
 
         result = trainer.train(resume_from_checkpoint=self.config.tr_args.resume_from_checkpoint)

--- a/colpali_engine/trainer/colmodel_training.py
+++ b/colpali_engine/trainer/colmodel_training.py
@@ -184,26 +184,7 @@ class ColModelTraining:
         with torch.no_grad():
             for dataloader in [dataloader_with_query, dataloader_without_query]:
                 for batch in tqdm(dataloader):
-                    if "doc_pixel_values" not in batch:
-                        doc = self.model(
-                            input_ids=batch["doc_input_ids"].to(device),
-                            attention_mask=batch["doc_attention_mask"].to(device),
-                        )
-
-                    else:
-                        if "doc_pixel_attention_mask" in batch:
-                            doc = self.model(
-                                input_ids=batch["doc_input_ids"].to(device),
-                                attention_mask=batch["doc_attention_mask"].to(device),
-                                pixel_values=batch["doc_pixel_values"].to(device),
-                                pixel_attention_mask=batch["doc_pixel_attention_mask"].to(device),
-                            )
-                        else:
-                            doc = self.model(
-                                input_ids=batch["doc_input_ids"].to(device),
-                                attention_mask=batch["doc_attention_mask"].to(device),
-                                pixel_values=batch["doc_pixel_values"].to(device),
-                            )
+                    doc = self.model(**{k[4:]: v.to(device) for k, v in batch.items() if k.startswith("doc")})
 
                     ps.extend(list(torch.unbind(doc.to("cpu"))))
 

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -10,22 +10,6 @@ class ContrastiveTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
-
-        # # hacky, to make sure the scatter in DDP is done correctly
-        # if "doc_image_grid_thw" in inputs:
-        #     # compute pixel_values offsets
-        #     offsets = inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2]
-        #     # print(offsets)
-        #     # separate pixel_values for each image
-        #     pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
-        #     # pad pixel_values to the same length to be able to make it into a tensor
-        #     max_length = max([len(pv) for pv in pixel_values])
-        #     pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
-        #     inputs["doc_pixel_values"] = torch.stack(pixel_values)
-
-            # print(inputs["doc_pixel_values"].shape)
-
-
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
         if "neg_doc_input_ids" in inputs:
             neg_doc_outputs = model(**{k[8:]: v for k, v in inputs.items() if k.startswith("neg_doc")})

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -24,8 +24,6 @@ class ContrastiveTrainer(Trainer):
         if not prediction_loss_only:
             raise ValueError("prediction_step is only called with prediction_loss_only=True")
 
-        breakpoint()
-
         with torch.no_grad():
             doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
             query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -10,6 +10,22 @@ class ContrastiveTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
+
+        # hacky, to make sure the scatter in DDP is done correctly
+        if "image_grid_thw" in inputs:
+            # compute pixel_values offsets
+            offsets = torch.cumsum(inputs["image_grid_thw"][:, 1] * inputs["image_grid_thw"][:, 2], 0)
+            print(offsets)
+            # separate pixel_values for each image
+            pixel_values = torch.split(inputs["pixel_values"], offsets.tolist())
+            # pad pixel_values to the same length to be able to make it into a tensor
+            max_length = max([len(pv) for pv in pixel_values])
+            pixel_values = [torch.cat([pv, torch.zeros(max_length - len(pv), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
+            inputs["pixel_values"] = torch.stack(pixel_values)
+
+            print(inputs["pixel_values"].shape)
+
+
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
         if "neg_doc_input_ids" in inputs:
             neg_doc_outputs = model(**{k[8:]: v for k, v in inputs.items() if k.startswith("neg_doc")})

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -12,18 +12,18 @@ class ContrastiveTrainer(Trainer):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
 
         # hacky, to make sure the scatter in DDP is done correctly
-        if "image_grid_thw" in inputs:
+        if "doc_image_grid_thw" in inputs:
             # compute pixel_values offsets
-            offsets = torch.cumsum(inputs["image_grid_thw"][:, 1] * inputs["image_grid_thw"][:, 2], 0)
+            offsets = torch.cumsum(inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2], 0)
             print(offsets)
             # separate pixel_values for each image
-            pixel_values = torch.split(inputs["pixel_values"], offsets.tolist())
+            pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
             # pad pixel_values to the same length to be able to make it into a tensor
             max_length = max([len(pv) for pv in pixel_values])
             pixel_values = [torch.cat([pv, torch.zeros(max_length - len(pv), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
-            inputs["pixel_values"] = torch.stack(pixel_values)
+            inputs["doc_pixel_values"] = torch.stack(pixel_values)
 
-            print(inputs["pixel_values"].shape)
+            print(inputs["doc_pixel_values"].shape)
 
 
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -24,6 +24,8 @@ class ContrastiveTrainer(Trainer):
         if not prediction_loss_only:
             raise ValueError("prediction_step is only called with prediction_loss_only=True")
 
+        breakpoint()
+
         with torch.no_grad():
             doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
             query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -20,7 +20,7 @@ class ContrastiveTrainer(Trainer):
             pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
             # pad pixel_values to the same length to be able to make it into a tensor
             max_length = max([len(pv) for pv in pixel_values])
-            pixel_values = [torch.cat([pv, torch.zeros(max_length - len(pv), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
+            pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
             inputs["doc_pixel_values"] = torch.stack(pixel_values)
 
             print(inputs["doc_pixel_values"].shape)

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -10,6 +10,7 @@ class ContrastiveTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
+        # feed only kwargs with 'doc_' prefix
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
         if "neg_doc_input_ids" in inputs:
             neg_doc_outputs = model(**{k[8:]: v for k, v in inputs.items() if k.startswith("neg_doc")})
@@ -25,6 +26,7 @@ class ContrastiveTrainer(Trainer):
             raise ValueError("prediction_step is only called with prediction_loss_only=True")
 
         with torch.no_grad():
+            # feed only kwargs with 'doc_' prefix
             doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
             query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
             if "neg_doc_input_ids" in inputs:

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -11,17 +11,17 @@ class ContrastiveTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
 
-        # hacky, to make sure the scatter in DDP is done correctly
-        if "doc_image_grid_thw" in inputs:
-            # compute pixel_values offsets
-            offsets = inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2]
-            # print(offsets)
-            # separate pixel_values for each image
-            pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
-            # pad pixel_values to the same length to be able to make it into a tensor
-            max_length = max([len(pv) for pv in pixel_values])
-            pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
-            inputs["doc_pixel_values"] = torch.stack(pixel_values)
+        # # hacky, to make sure the scatter in DDP is done correctly
+        # if "doc_image_grid_thw" in inputs:
+        #     # compute pixel_values offsets
+        #     offsets = inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2]
+        #     # print(offsets)
+        #     # separate pixel_values for each image
+        #     pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
+        #     # pad pixel_values to the same length to be able to make it into a tensor
+        #     max_length = max([len(pv) for pv in pixel_values])
+        #     pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
+        #     inputs["doc_pixel_values"] = torch.stack(pixel_values)
 
             # print(inputs["doc_pixel_values"].shape)
 

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -11,31 +11,6 @@ class ContrastiveTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
-        # if self.is_vision_model:
-        #     if "doc_pixel_attention_mask" in inputs:
-        #         doc_outputs = model(
-        #             input_ids=inputs["doc_input_ids"],
-        #             attention_mask=inputs["doc_attention_mask"],
-        #             pixel_values=inputs["doc_pixel_values"],
-        #             pixel_attention_mask=inputs["doc_pixel_attention_mask"],
-        #         )
-        #     # TODO: clean this up by just passing all args with doc suffix that are received
-        #     elif "doc_image_grid_thw" in inputs:
-        #         doc_outputs = model(
-        #             input_ids=inputs["doc_input_ids"],
-        #             attention_mask=inputs["doc_attention_mask"],
-        #             pixel_values=inputs["doc_pixel_values"],
-        #             image_grid_thw=inputs["doc_image_grid_thw"],
-        #         )
-        #     else:
-        #         doc_outputs = model(
-        #             input_ids=inputs["doc_input_ids"],
-        #             attention_mask=inputs["doc_attention_mask"],
-        #             pixel_values=inputs["doc_pixel_values"],
-        #         )
-        # else:
-        #     doc_outputs = model(input_ids=inputs["doc_input_ids"], attention_mask=inputs["doc_attention_mask"])
-
         loss = self.loss_func(query_outputs, doc_outputs)
         return (loss, (query_outputs, doc_outputs)) if return_outputs else loss
 

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -11,6 +11,11 @@ class ContrastiveTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
+        if "neg_doc_input_ids" in inputs:
+            neg_doc_outputs = model(**{k[8:]: v for k, v in inputs.items() if k.startswith("neg_doc")})
+            loss = self.loss_func(query_outputs, doc_outputs, neg_doc_outputs)
+            return (loss, (query_outputs, doc_outputs, neg_doc_outputs)) if return_outputs else loss
+
         loss = self.loss_func(query_outputs, doc_outputs)
         return (loss, (query_outputs, doc_outputs)) if return_outputs else loss
 
@@ -22,94 +27,10 @@ class ContrastiveTrainer(Trainer):
         with torch.no_grad():
             doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
             query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
+            if "neg_doc_input_ids" in inputs:
+                neg_doc_outputs = model(**{k[8:]: v for k, v in inputs.items() if k.startswith("neg_doc")})
+                loss = self.loss_func(query_outputs, doc_outputs, neg_doc_outputs)
+                return loss, None, None
+
             loss = self.loss_func(query_outputs, doc_outputs)
-            return loss, None, None
-
-
-class ContrastiveNegativeTrainer(Trainer):
-    def __init__(self, loss_func, is_vision_model, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.loss_func = loss_func
-        self.is_vision_model = is_vision_model
-
-    def compute_loss(self, model, inputs, return_outputs=False):
-        query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
-
-        if self.is_vision_model:
-            if "doc_pixel_attention_mask" not in inputs:
-                doc_outputs = model(
-                    input_ids=inputs["doc_input_ids"],
-                    attention_mask=inputs["doc_attention_mask"],
-                    pixel_values=inputs["doc_pixel_values"],
-                )
-            else:
-                doc_outputs = model(
-                    input_ids=inputs["doc_input_ids"],
-                    attention_mask=inputs["doc_attention_mask"],
-                    pixel_values=inputs["doc_pixel_values"],
-                    pixel_attention_mask=inputs["doc_pixel_attention_mask"],
-                )
-
-            if "neg_doc_pixel_attention_mask" not in inputs:
-                neg_doc_outputs = model(
-                    input_ids=inputs["neg_doc_input_ids"],
-                    attention_mask=inputs["neg_doc_attention_mask"],
-                    pixel_values=inputs["neg_doc_pixel_values"],
-                )
-            else:
-                neg_doc_outputs = model(
-                    input_ids=inputs["neg_doc_input_ids"],
-                    attention_mask=inputs["neg_doc_attention_mask"],
-                    pixel_values=inputs["neg_doc_pixel_values"],
-                    pixel_attention_mask=inputs["neg_doc_pixel_attention_mask"],
-                )
-        else:
-            raise NotImplementedError("Only vision models are supported for now")
-
-        loss = self.loss_func(query_outputs, doc_outputs, neg_doc_outputs)
-        return (loss, (query_outputs, doc_outputs, neg_doc_outputs)) if return_outputs else loss
-
-    def prediction_step(self, model, inputs, prediction_loss_only, ignore_keys=True):
-        """This function is used to generate predictions and return the loss for the given inputs."""
-        if not prediction_loss_only:
-            raise ValueError("prediction_step is only called with prediction_loss_only=True")
-
-        with torch.no_grad():
-            if self.is_vision_model:
-                if "doc_pixel_attention_mask" not in inputs:
-                    doc_outputs = model(
-                        input_ids=inputs["doc_input_ids"],
-                        attention_mask=inputs["doc_attention_mask"],
-                        pixel_values=inputs["doc_pixel_values"],
-                    )
-                else:
-                    doc_outputs = model(
-                        input_ids=inputs["doc_input_ids"],
-                        attention_mask=inputs["doc_attention_mask"],
-                        pixel_values=inputs["doc_pixel_values"],
-                        pixel_attention_mask=inputs["doc_pixel_attention_mask"],
-                    )
-                if "neg_doc_pixel_attention_mask" not in inputs:
-                    neg_doc_outputs = model(
-                        input_ids=inputs["neg_doc_input_ids"],
-                        attention_mask=inputs["neg_doc_attention_mask"],
-                        pixel_values=inputs["neg_doc_pixel_values"],
-                    )
-                else:
-                    neg_doc_outputs = model(
-                        input_ids=inputs["neg_doc_input_ids"],
-                        attention_mask=inputs["neg_doc_attention_mask"],
-                        pixel_values=inputs["neg_doc_pixel_values"],
-                        pixel_attention_mask=inputs["neg_doc_pixel_attention_mask"],
-                    )
-                query_outputs = model(
-                    input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"]
-                )
-            else:
-                query_outputs = model(
-                    input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"]
-                )
-                doc_outputs = model(input_ids=inputs["doc_input_ids"], attention_mask=inputs["doc_attention_mask"])
-
-            loss = self.loss_func(query_outputs, doc_outputs, neg_doc_outputs)
             return loss, None, None

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -20,29 +20,8 @@ class ContrastiveTrainer(Trainer):
             raise ValueError("prediction_step is only called with prediction_loss_only=True")
 
         with torch.no_grad():
-            if self.is_vision_model:
-                if "doc_pixel_attention_mask" not in inputs:
-                    doc_outputs = model(
-                        input_ids=inputs["doc_input_ids"],
-                        attention_mask=inputs["doc_attention_mask"],
-                        pixel_values=inputs["doc_pixel_values"],
-                    )
-                else:
-                    doc_outputs = model(
-                        input_ids=inputs["doc_input_ids"],
-                        attention_mask=inputs["doc_attention_mask"],
-                        pixel_values=inputs["doc_pixel_values"],
-                        pixel_attention_mask=inputs["doc_pixel_attention_mask"],
-                    )
-                query_outputs = model(
-                    input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"]
-                )
-            else:
-                query_outputs = model(
-                    input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"]
-                )
-                doc_outputs = model(input_ids=inputs["doc_input_ids"], attention_mask=inputs["doc_attention_mask"])
-
+            doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
+            query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
             loss = self.loss_func(query_outputs, doc_outputs)
             return loss, None, None
 

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -14,7 +14,7 @@ class ContrastiveTrainer(Trainer):
         # hacky, to make sure the scatter in DDP is done correctly
         if "doc_image_grid_thw" in inputs:
             # compute pixel_values offsets
-            offsets = torch.cumsum(inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2], 0)
+            offsets = inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2]
             print(offsets)
             # separate pixel_values for each image
             pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -10,30 +10,31 @@ class ContrastiveTrainer(Trainer):
 
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])
-        if self.is_vision_model:
-            if "doc_pixel_attention_mask" in inputs:
-                doc_outputs = model(
-                    input_ids=inputs["doc_input_ids"],
-                    attention_mask=inputs["doc_attention_mask"],
-                    pixel_values=inputs["doc_pixel_values"],
-                    pixel_attention_mask=inputs["doc_pixel_attention_mask"],
-                )
-            # TODO: clean this up by just passing all args with doc suffix that are received
-            elif "doc_image_grid_thw" in inputs:
-                doc_outputs = model(
-                    input_ids=inputs["doc_input_ids"],
-                    attention_mask=inputs["doc_attention_mask"],
-                    pixel_values=inputs["doc_pixel_values"],
-                    image_grid_thw=inputs["doc_image_grid_thw"],
-                )
-            else:
-                doc_outputs = model(
-                    input_ids=inputs["doc_input_ids"],
-                    attention_mask=inputs["doc_attention_mask"],
-                    pixel_values=inputs["doc_pixel_values"],
-                )
-        else:
-            doc_outputs = model(input_ids=inputs["doc_input_ids"], attention_mask=inputs["doc_attention_mask"])
+        doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})
+        # if self.is_vision_model:
+        #     if "doc_pixel_attention_mask" in inputs:
+        #         doc_outputs = model(
+        #             input_ids=inputs["doc_input_ids"],
+        #             attention_mask=inputs["doc_attention_mask"],
+        #             pixel_values=inputs["doc_pixel_values"],
+        #             pixel_attention_mask=inputs["doc_pixel_attention_mask"],
+        #         )
+        #     # TODO: clean this up by just passing all args with doc suffix that are received
+        #     elif "doc_image_grid_thw" in inputs:
+        #         doc_outputs = model(
+        #             input_ids=inputs["doc_input_ids"],
+        #             attention_mask=inputs["doc_attention_mask"],
+        #             pixel_values=inputs["doc_pixel_values"],
+        #             image_grid_thw=inputs["doc_image_grid_thw"],
+        #         )
+        #     else:
+        #         doc_outputs = model(
+        #             input_ids=inputs["doc_input_ids"],
+        #             attention_mask=inputs["doc_attention_mask"],
+        #             pixel_values=inputs["doc_pixel_values"],
+        #         )
+        # else:
+        #     doc_outputs = model(input_ids=inputs["doc_input_ids"], attention_mask=inputs["doc_attention_mask"])
 
         loss = self.loss_func(query_outputs, doc_outputs)
         return (loss, (query_outputs, doc_outputs)) if return_outputs else loss

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -6,7 +6,7 @@ class ContrastiveTrainer(Trainer):
     def __init__(self, loss_func, is_vision_model, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.loss_func = loss_func
-        self.is_vision_model = is_vision_model
+        self.is_vision_model = is_vision_model  # Unused argument, will be removed in 0.4.0
 
     def compute_loss(self, model, inputs, return_outputs=False):
         query_outputs = model(input_ids=inputs["query_input_ids"], attention_mask=inputs["query_attention_mask"])

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -15,7 +15,7 @@ class ContrastiveTrainer(Trainer):
         if "doc_image_grid_thw" in inputs:
             # compute pixel_values offsets
             offsets = inputs["doc_image_grid_thw"][:, 1] * inputs["doc_image_grid_thw"][:, 2]
-            print(offsets)
+            # print(offsets)
             # separate pixel_values for each image
             pixel_values = torch.split(inputs["doc_pixel_values"], offsets.tolist())
             # pad pixel_values to the same length to be able to make it into a tensor
@@ -23,7 +23,7 @@ class ContrastiveTrainer(Trainer):
             pixel_values = [torch.cat([pv, torch.zeros((max_length - len(pv), pv.shape[1]), dtype=pv.dtype, device=pv.device)]) for pv in pixel_values]
             inputs["doc_pixel_values"] = torch.stack(pixel_values)
 
-            print(inputs["doc_pixel_values"].shape)
+            # print(inputs["doc_pixel_values"].shape)
 
 
         doc_outputs = model(**{k[4:]: v for k, v in inputs.items() if k.startswith("doc")})

--- a/colpali_engine/utils/dataset_transformation.py
+++ b/colpali_engine/utils/dataset_transformation.py
@@ -45,8 +45,6 @@ def load_train_set_detailed() -> DatasetDict:
     dataset = cast(Dataset, concatenate_datasets(ds_tot))
     dataset = dataset.shuffle(seed=42)
     # split into train and test
-    # dataset_eval = dataset.select(range(500))
-    # dataset = dataset.select(range(500, len(dataset)))
     dataset_eval = dataset.select(range(500))
     dataset = dataset.select(range(500, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})

--- a/colpali_engine/utils/dataset_transformation.py
+++ b/colpali_engine/utils/dataset_transformation.py
@@ -45,8 +45,10 @@ def load_train_set_detailed() -> DatasetDict:
     dataset = cast(Dataset, concatenate_datasets(ds_tot))
     dataset = dataset.shuffle(seed=42)
     # split into train and test
-    dataset_eval = dataset.select(range(500))
-    dataset = dataset.select(range(500, len(dataset)))
+    # dataset_eval = dataset.select(range(500))
+    # dataset = dataset.select(range(500, len(dataset)))
+    dataset_eval = dataset.select(range(320))
+    dataset = dataset.select(range(320, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})
     return ds_dict
 

--- a/colpali_engine/utils/dataset_transformation.py
+++ b/colpali_engine/utils/dataset_transformation.py
@@ -47,8 +47,8 @@ def load_train_set_detailed() -> DatasetDict:
     # split into train and test
     # dataset_eval = dataset.select(range(500))
     # dataset = dataset.select(range(500, len(dataset)))
-    dataset_eval = dataset.select(range(320))
-    dataset = dataset.select(range(320, len(dataset)))
+    dataset_eval = dataset.select(range(512))
+    dataset = dataset.select(range(512, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})
     return ds_dict
 
@@ -103,8 +103,8 @@ def load_train_set_ir_negs() -> Tuple[DatasetDict, Dataset]:
     base_path = "./data_dir/" if USE_LOCAL_DATASET else "manu/"
     dataset = cast(Dataset, load_dataset(base_path + "colpali-data-ir", split="train"))
 
-    dataset_eval = dataset.select(range(500))
-    dataset = dataset.select(range(500, len(dataset)))
+    dataset_eval = dataset.select(range(512))
+    dataset = dataset.select(range(512, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})
 
     anchor_ds = cast(Dataset, load_dataset(base_path + "colpali-data", split="train"))

--- a/colpali_engine/utils/dataset_transformation.py
+++ b/colpali_engine/utils/dataset_transformation.py
@@ -47,8 +47,8 @@ def load_train_set_detailed() -> DatasetDict:
     # split into train and test
     # dataset_eval = dataset.select(range(500))
     # dataset = dataset.select(range(500, len(dataset)))
-    dataset_eval = dataset.select(range(512))
-    dataset = dataset.select(range(512, len(dataset)))
+    dataset_eval = dataset.select(range(500))
+    dataset = dataset.select(range(500, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})
     return ds_dict
 
@@ -103,8 +103,8 @@ def load_train_set_ir_negs() -> Tuple[DatasetDict, Dataset]:
     base_path = "./data_dir/" if USE_LOCAL_DATASET else "manu/"
     dataset = cast(Dataset, load_dataset(base_path + "colpali-data-ir", split="train"))
 
-    dataset_eval = dataset.select(range(512))
-    dataset = dataset.select(range(512, len(dataset)))
+    dataset_eval = dataset.select(range(500))
+    dataset = dataset.select(range(500, len(dataset)))
     ds_dict = DatasetDict({"train": dataset, "test": dataset_eval})
 
     anchor_ds = cast(Dataset, load_dataset(base_path + "colpali-data", split="train"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "requests",
     "torch>=2.2.0",
     "transformers>=4.45.0",
+    "qwen-vl-utils==0.0.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "requests",
     "torch>=2.2.0",
     "transformers>=4.45.0",
-    "qwen-vl-utils==0.0.4",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 
 [project.optional-dependencies]
 train = [
-    "accelerate>=0.34.0", # accelerate>=0.32.1",
+    "accelerate>=0.34.0",
     "bitsandbytes",
     "configue>=5.0.0",
     "datasets>=2.19.1",

--- a/scripts/configs/qwen2/train_colqwen2_hardneg_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_hardneg_model.yaml
@@ -1,0 +1,43 @@
+config:
+  (): colpali_engine.trainer.colmodel_training.ColModelTrainingConfig
+  output_dir: !path ../../../models/colqwen2-multi-hardneg
+  processor:
+    (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
+    class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor
+    pretrained_model_name_or_path:  "./models/Qwen2-VL-2B-Instruct" # "./models/paligemma-3b-mix-448"
+    # max_length: 50
+
+  model:
+    (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
+    class_to_instanciate: !ext colpali_engine.models.ColQwen2
+    pretrained_model_name_or_path: "./models/Qwen2-VL-2B-Instruct"
+    torch_dtype:  !ext torch.bfloat16
+    use_cache: false
+#    device_map: "auto"
+#    quantization_config:
+#      (): transformers.BitsAndBytesConfig
+#      load_in_4bit: true
+#      bnb_4bit_quant_type: "nf4"
+#      bnb_4bit_compute_dtype:  "bfloat16"
+#      bnb_4bit_use_double_quant: true
+
+  dataset_loading_func: !ext colpali_engine.utils.dataset_transformation.load_train_set_ir_negs
+  eval_dataset_loader: !import ../data/test_data.yaml
+
+  # max_length: 50
+  run_eval: true
+  add_suffix: true
+  loss_func:
+    (): colpali_engine.loss.late_interaction_losses.ColbertPairwiseNegativeCELoss
+  tr_args: !import ../tr_args/default_tr_args.yaml
+  peft_config:
+    (): peft.LoraConfig
+    r: 32
+    lora_alpha: 32
+    lora_dropout: 0.1
+    init_lora_weights: "gaussian"
+    bias: "none"
+    task_type: "FEATURE_EXTRACTION"
+    target_modules: '(.*(model).*(down_proj|gate_proj|up_proj|k_proj|q_proj|v_proj|o_proj).*$|.*(custom_text_proj).*$)'
+    # target_modules: '(.*(language_model).*(down_proj|gate_proj|up_proj|k_proj|q_proj|v_proj|o_proj).*$|.*(custom_text_proj).*$)'
+

--- a/scripts/configs/qwen2/train_colqwen2_hardneg_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_hardneg_model.yaml
@@ -10,7 +10,7 @@ config:
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2
-    pretrained_model_name_or_path: "./models/Qwen2-VL-2B-Instruct"
+    pretrained_model_name_or_path: "./models/colqwen2_base"
     torch_dtype:  !ext torch.bfloat16
     use_cache: false
 #    device_map: "auto"

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -22,7 +22,7 @@ config:
   dataset_loading_func: !ext colpali_engine.utils.dataset_transformation.load_train_set_detailed
   eval_dataset_loader: !import ../data/test_data.yaml
 
-  max_length: 50
+  max_length: 500
   run_eval: true
   add_suffix: true
   loss_func:

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -22,7 +22,7 @@ config:
   dataset_loading_func: !ext colpali_engine.utils.dataset_transformation.load_train_set_detailed
   eval_dataset_loader: !import ../data/test_data.yaml
 
-  max_length: 500
+  max_length: 50
   run_eval: true
   add_suffix: true
   loss_func:

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -1,6 +1,6 @@
 config:
   (): colpali_engine.trainer.colmodel_training.ColModelTrainingConfig
-  output_dir: !path ../../../models/colqwen2
+  output_dir: !path ../../../models/colqwen2-multi
   processor:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -10,7 +10,7 @@ config:
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2
-    pretrained_model_name_or_path: "./models/Qwen2-VL-2B-Instruct"
+    pretrained_model_name_or_path: "./models/colqwen2_base"
     torch_dtype:  !ext torch.bfloat16
     use_cache: false
 #    device_map: "auto"

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -6,6 +6,8 @@ config:
     class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor
     pretrained_model_name_or_path:  "./models/Qwen2-VL-2B-Instruct" # "./models/paligemma-3b-mix-448"
     max_length: 50
+    min_pixels: 4 * 28 * 28
+    max_pixels: 2560 * 28 * 28
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -5,13 +5,14 @@ config:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor
     pretrained_model_name_or_path:  "./models/Qwen2-VL-2B-Instruct" # "./models/paligemma-3b-mix-448"
-    max_length: 50
+    # max_length: 50
 
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2
     pretrained_model_name_or_path: "./models/Qwen2-VL-2B-Instruct"
     torch_dtype:  !ext torch.bfloat16
+    use_cache: false
 #    device_map: "auto"
 #    quantization_config:
 #      (): transformers.BitsAndBytesConfig
@@ -23,7 +24,7 @@ config:
   dataset_loading_func: !ext colpali_engine.utils.dataset_transformation.load_train_set_detailed
   eval_dataset_loader: !import ../data/test_data.yaml
 
-  max_length: 50
+  # max_length: 50
   run_eval: true
   add_suffix: true
   loss_func:

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -6,8 +6,7 @@ config:
     class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor
     pretrained_model_name_or_path:  "./models/Qwen2-VL-2B-Instruct" # "./models/paligemma-3b-mix-448"
     max_length: 50
-    min_pixels: 3136 # 4 * 28 * 28
-    max_pixels: 802816 # 1024 * 28 * 28
+
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2

--- a/scripts/configs/qwen2/train_colqwen2_model.yaml
+++ b/scripts/configs/qwen2/train_colqwen2_model.yaml
@@ -6,8 +6,8 @@ config:
     class_to_instanciate: !ext colpali_engine.models.ColQwen2Processor
     pretrained_model_name_or_path:  "./models/Qwen2-VL-2B-Instruct" # "./models/paligemma-3b-mix-448"
     max_length: 50
-    min_pixels: 4 * 28 * 28
-    max_pixels: 2560 * 28 * 28
+    min_pixels: 3136 # 4 * 28 * 28
+    max_pixels: 802816 # 1024 * 28 * 28
   model:
     (): colpali_engine.utils.transformers_wrappers.AllPurposeWrapper
     class_to_instanciate: !ext colpali_engine.models.ColQwen2

--- a/scripts/configs/tr_args/default_neg_tr_args.yaml
+++ b/scripts/configs/tr_args/default_neg_tr_args.yaml
@@ -10,6 +10,7 @@ eval_strategy: "steps"
 # dataloader_num_workers: 8
 # bf16: true
 save_steps: 500
+max_steps: 3698
 logging_steps: 10
 eval_steps: 50
 warmup_steps: 100

--- a/scripts/configs/tr_args/default_neg_tr_args.yaml
+++ b/scripts/configs/tr_args/default_neg_tr_args.yaml
@@ -10,7 +10,6 @@ eval_strategy: "steps"
 # dataloader_num_workers: 8
 # bf16: true
 save_steps: 500
-max_steps: 3698
 logging_steps: 10
 eval_steps: 50
 warmup_steps: 100

--- a/scripts/configs/tr_args/default_tr_args.yaml
+++ b/scripts/configs/tr_args/default_tr_args.yaml
@@ -11,7 +11,7 @@ eval_strategy: "steps"
 # bf16: true
 save_steps: 500
 logging_steps: 10
-eval_steps: 10000
+eval_steps: 100
 warmup_steps: 500
 learning_rate: 5e-5
 save_total_limit: 1

--- a/scripts/configs/tr_args/default_tr_args.yaml
+++ b/scripts/configs/tr_args/default_tr_args.yaml
@@ -11,8 +11,8 @@ eval_strategy: "steps"
 # bf16: true
 save_steps: 500
 logging_steps: 10
-eval_steps: 100
-warmup_steps: 1000
+eval_steps: 10000
+warmup_steps: 500
 learning_rate: 5e-5
 save_total_limit: 1
 # optim: "paged_adamw_8bit"

--- a/scripts/configs/tr_args/default_tr_args.yaml
+++ b/scripts/configs/tr_args/default_tr_args.yaml
@@ -11,8 +11,8 @@ eval_strategy: "steps"
 # bf16: true
 save_steps: 500
 logging_steps: 10
-eval_steps: 10
-warmup_steps: 100
+eval_steps: 100
+warmup_steps: 1000
 learning_rate: 5e-5
 save_total_limit: 1
 # optim: "paged_adamw_8bit"

--- a/scripts/configs/tr_args/default_tr_args.yaml
+++ b/scripts/configs/tr_args/default_tr_args.yaml
@@ -11,7 +11,7 @@ eval_strategy: "steps"
 # bf16: true
 save_steps: 500
 logging_steps: 10
-eval_steps: 50
+eval_steps: 10
 warmup_steps: 100
 learning_rate: 5e-5
 save_total_limit: 1


### PR DESCRIPTION
## Description

Add ColQwen2

### Added

- Add Qwen2-VL support

### Changed

- Greatly simplify routing logic in Trainer selection and when feeding arguments to the model forward pass (refacto)
- Bumped transformers version to 4.45.0 to get Qwen2-VL support

### Fixed

- Fix bug in HardNegCollator since 0.3.0

## Notes: Tentative PR

Still some things to fix / figure out:
- How do we deal with the variable image resolution (and not squared) 
- --> allow for arbitrary shape ? set it in the config ? arbitrary is probably best but code should be adapted to be okay with that !
- -> what perf impact does it make ?
- Padding (left vs right, what can be done etc)
- verifying that token pre-processing is "sufficiently" in domain and makes sense (I think it does)