### PR TITLE
Fix and improve run inference example script

### DIFF
--- a/colpali_engine/utils/torch_utils.py
+++ b/colpali_engine/utils/torch_utils.py
@@ -1,9 +1,12 @@
 import gc
 import logging
+from typing import List, TypeVar
 
 import torch
+from torch.utils.data import Dataset
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T")
 
 
 def get_torch_device(device: str = "auto") -> str:
@@ -35,3 +38,14 @@ def tear_down_torch():
     """
     gc.collect()
     torch.cuda.empty_cache()
+
+
+class ListDataset(Dataset[T]):
+    def __init__(self, elements: List[T]):
+        self.elements = elements
+
+    def __len__(self) -> int:
+        return len(self.elements)
+
+    def __getitem__(self, idx: int) -> T:
+        return self.elements[idx]

--- a/scripts/infer/run_inference_with_python.py
+++ b/scripts/infer/run_inference_with_python.py
@@ -2,7 +2,6 @@ import pprint
 from typing import List, cast
 
 import torch
-import typer
 from datasets import Dataset, load_dataset
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -87,6 +86,8 @@ def main():
     else:
         print("The top-1 retrieved documents are incorrect.")
 
+    return
+
 
 if __name__ == "__main__":
-    typer.run(main)
+    main()

--- a/scripts/infer/run_inference_with_python.py
+++ b/scripts/infer/run_inference_with_python.py
@@ -5,22 +5,33 @@ import typer
 from datasets import Dataset, load_dataset
 from torch.utils.data import DataLoader
 from tqdm import tqdm
-from transformers import AutoProcessor
 
 from colpali_engine.models import ColPali
+from colpali_engine.models.paligemma.colpali.processing_colpali import ColPaliProcessor
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
+from colpali_engine.utils.torch_utils import get_torch_device
 
 
 def main() -> None:
-    """Example script to run inference with ColPali"""
+    """
+    Example script to run inference with ColPali
+    """
+
+    device = get_torch_device("auto")
+    print(f"Device used: {device}")
+
+    # Define adapter name
+    base_model_name = "vidore/colpaligemma-3b-pt-448-base"
+    adapter_name = "vidore/colpali-v1.2"
 
     # Load model
-    model_name = "vidore/colpali-v1.2"
     model = ColPali.from_pretrained(
-        "vidore/colpaligemma-3b-pt-448-base", torch_dtype=torch.bfloat16, device_map="cuda"
+        base_model_name,
+        torch_dtype=torch.bfloat16,
+        device_map=device,
     ).eval()
-    model.load_adapter(model_name)
-    processor = AutoProcessor.from_pretrained(model_name)
+    model.load_adapter(adapter_name)
+    processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained("google/paligemma-3b-mix-448"))
 
     if not isinstance(processor, BaseVisualRetrieverProcessor):
         raise ValueError("Processor should be a BaseVisualRetrieverProcessor")
@@ -28,7 +39,7 @@ def main() -> None:
     images = cast(Dataset, load_dataset("vidore/docvqa_test_subsampled", split="test"))["image"]
     queries = ["From which university does James V. Fiorca come ?", "Who is the japanese prime minister?"]
 
-    # run inference - docs
+    # Run inference - docs
     dataloader = DataLoader(
         images,
         batch_size=4,
@@ -42,7 +53,7 @@ def main() -> None:
             embeddings_doc = model(**batch_doc)
         ds.extend(list(torch.unbind(embeddings_doc.to("cpu"))))
 
-    # run inference - queries
+    # Run inference - queries
     dataloader = DataLoader(
         queries,
         batch_size=4,


### PR DESCRIPTION
## Description

This PR concerns the run inference example script:

- Address https://github.com/illuin-tech/colpali/issues/57
- Improve code clarity
- Add sanity check
- Remove the need for `typer`

## Features

### Added

- Add sanity check in the run inference example script

### Changed

- Improve code clarity the run inference example script
- Subset the example dataset in the run inference example script

### Removed

- Remove the need for `typer` in the run inference example script

## Test

```bash
❯ python scripts/infer/run_inference_with_python.py
Device used: mps
/Users/tony/Documents/illuin-repositories/colpali/.venv/lib/python3.11/site-packages/transformers/models/paligemma/configuration_paligemma.py:137: FutureWarning: The `vocab_size` attribute is deprecated and will be removed in v4.44, Please use `text_config.vocab_size` instead.
  warnings.warn(
`config.hidden_act` is ignored, you should use `config.hidden_activation` instead.
Gemma's activation function will be set to `gelu_pytorch_tanh`. Please, use
`config.hidden_activation` if you want to override this behaviour.
See https://github.com/huggingface/transformers/pull/29402 for more details.
Loading checkpoint shards: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████Loading checkpoint shards: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:09<00:00,  4.64s/it]
/Users/tony/Documents/illuin-repositories/colpali/.venv/lib/python3.11/site-packages/bitsandbytes/cextension.py:34: UserWarning: The installed version of bitsandbytes was compiled without GPU support. 8-bit optimizers, 8-bit multiplication, and GPU quantization are unavailable.
  warn("The installed version of bitsandbytes was compiled without GPU support. "
'NoneType' object has no attribute 'cadam32bit_grad_fp32'
Selected queries:
{12: 'What is the brand name of the ITC personal care product advertised here?',
 15: 'What is the % Promoted Volume in EDLP stores?'}
100%|█████████████████████████████████████████| 4/4 [01:01<00:00, 15.33s/it]
Indices of the top-1 retrieved documents for each query: [12 15]
The top-1 retrieved documents are correct.
```
