### PR TITLE
Fix Broken Inference Script Example Link in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ scores = processor.score_multi_vector(querry_embeddings, image_embeddings)
 
 ### Inference
 
-You can find an example [here](https://github.com/illuin-tech/colpali/blob/2c75550b1fe15ee4ec56521dc155116631ae083f/scripts/infer/run_inference_with_python.py#L33). If you need an indexing system, we recommend using [`byaldi`](https://github.com/AnswerDotAI/byaldi) - [RAGatouille](https://github.com/AnswerDotAI/RAGatouille)'s little sister 🐭 - which share a similar API and leverages our `colpali-engine` package.
+You can find an example [here](https://github.com/illuin-tech/colpali/blob/main/scripts/infer/run_inference_with_python.py). If you need an indexing system, we recommend using [`byaldi`](https://github.com/AnswerDotAI/byaldi) - [RAGatouille](https://github.com/AnswerDotAI/RAGatouille)'s little sister 🐭 - which share a similar API and leverages our `colpali-engine` package.
 
 ### Benchmarking
 


### PR DESCRIPTION
This [PR](https://github.com/illuin-tech/colpali/pull/59) just fixed some bugs in the inference script.
But the README link to this script is pointed to an older branch/commit and not the new code.
This change points to the main branch so users will be directed to the correct code.

Ofcourse users will need the most recent release for it all to work.