### PR TITLE
Load processor using ColPali model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,18 @@ from PIL import Image
 
 from colpali_engine.models import ColPali, ColPaliProcessor
 
+model_name = "vidore/colpali-v1.2"
+
 model = cast(
     ColPali,
     ColPali.from_pretrained(
-        "vidore/colpali-v1.2",
+        model_name,
         torch_dtype=torch.bfloat16,
         device_map="cuda:0",  # or "mps" if on Apple Silicon
     ),
 )
 
-processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained("google/paligemma-3b-mix-448"))
+processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(model_name))
 
 # Your inputs
 images = [

--- a/scripts/infer/run_inference_with_python.py
+++ b/scripts/infer/run_inference_with_python.py
@@ -20,18 +20,18 @@ def main():
     device = get_torch_device("auto")
     print(f"Device used: {device}")
 
-    # Define adapter name
-    base_model_name = "vidore/colpaligemma-3b-pt-448-base"
-    adapter_name = "vidore/colpali-v1.2"
+    # Model name
+    model_name = "vidore/colpali-v1.2"
 
     # Load model
     model = ColPali.from_pretrained(
-        base_model_name,
+        model_name,
         torch_dtype=torch.bfloat16,
         device_map=device,
     ).eval()
-    model.load_adapter(adapter_name)
-    processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained("google/paligemma-3b-mix-448"))
+
+    # Load processor
+    processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(model_name))
 
     if not isinstance(processor, BaseVisualRetrieverProcessor):
         raise ValueError("Processor should be a BaseVisualRetrieverProcessor")

--- a/tests/collators/test_visual_retriever_collator.py
+++ b/tests/collators/test_visual_retriever_collator.py
@@ -10,7 +10,7 @@ from colpali_engine.models.paligemma.colpali.processing_colpali import ColPaliPr
 class TestColPaliCollator:
     @pytest.fixture(scope="class")
     def colpali_processor_path(self) -> str:
-        return "google/paligemma-3b-mix-448"
+        return "vidore/colpali-v1.2"
 
     @pytest.fixture(scope="class")
     def processor_from_pretrained(self, colpali_processor_path: str) -> Generator[ColPaliProcessor, None, None]:

--- a/tests/models/paligemma/colpali/test_colpali_e2e.py
+++ b/tests/models/paligemma/colpali/test_colpali_e2e.py
@@ -8,19 +8,24 @@ from colpali_engine.models import ColPali, ColPaliProcessor
 from colpali_engine.utils.torch_utils import get_torch_device
 
 
+@pytest.fixture(scope="module")
+def colpali_model_name() -> str:
+    return "vidore/colpali-v1.2"
+
+
 @pytest.mark.slow
-def test_e2e_colpali():
+def test_e2e_colpali(colpali_model_name: str):
     model = cast(
         ColPali,
         ColPali.from_pretrained(
-            "vidore/colpali-v1.2",
+            colpali_model_name,
             torch_dtype=torch.bfloat16,
             device_map=get_torch_device("auto"),
         ),
     )
 
     try:
-        processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained("google/paligemma-3b-mix-448"))
+        processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(colpali_model_name))
 
         # Your inputs
         images = [

--- a/tests/models/paligemma/colpali/test_modeling_colpali.py
+++ b/tests/models/paligemma/colpali/test_modeling_colpali.py
@@ -12,19 +12,19 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def colpali_model_path() -> str:
+def colpali_model_name() -> str:
     return "vidore/colpali-v1.2"
 
 
 @pytest.fixture(scope="module")
-def colpali_from_pretrained(colpali_model_path: str) -> Generator[ColPali, None, None]:
+def colpali_from_pretrained(colpali_model_name: str) -> Generator[ColPali, None, None]:
     device = get_torch_device("auto")
     logger.info(f"Device used: {device}")
 
     yield cast(
         ColPali,
         ColPali.from_pretrained(
-            colpali_model_path,
+            colpali_model_name,
             torch_dtype=torch.bfloat16,
             device_map=device,
         ),
@@ -33,8 +33,8 @@ def colpali_from_pretrained(colpali_model_path: str) -> Generator[ColPali, None,
 
 
 @pytest.fixture(scope="module")
-def processor() -> Generator[ColPaliProcessor, None, None]:
-    yield cast(ColPaliProcessor, ColPaliProcessor.from_pretrained("google/paligemma-3b-mix-448"))
+def processor(colpali_model_name: str) -> Generator[ColPaliProcessor, None, None]:
+    yield cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(colpali_model_name))
 
 
 @pytest.mark.slow

--- a/tests/models/paligemma/colpali/test_processing_colpali.py
+++ b/tests/models/paligemma/colpali/test_processing_colpali.py
@@ -8,13 +8,13 @@ from colpali_engine.models import ColPaliProcessor
 
 
 @pytest.fixture(scope="module")
-def colpali_processor_path() -> str:
-    return "google/paligemma-3b-mix-448"
+def colpali_processor_name() -> str:
+    return "vidore/colpali-v1.2"
 
 
 @pytest.fixture(scope="module")
-def processor_from_pretrained(colpali_processor_path: str) -> Generator[ColPaliProcessor, None, None]:
-    yield cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(colpali_processor_path))
+def processor_from_pretrained(colpali_processor_name: str) -> Generator[ColPaliProcessor, None, None]:
+    yield cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(colpali_processor_name))
 
 
 def test_load_processor_from_pretrained(processor_from_pretrained: ColPaliProcessor):


### PR DESCRIPTION
## Description

Since the `preprocessor_config.json` is in the [ColPali Hf Hub repository](https://huggingface.co/vidore/colpali-v1.2/tree/main), it is possible to load the processor using the ColPali model name instead of the base PaliGemma name.

### Changes

- Use the ColPali model name to load ColPaliProcessor instead of the PaliGemma one

## Local tests

<img width="506" alt="Screenshot 2024-09-25 at 19 37 38" src="https://github.com/user-attachments/assets/18163f78-a7ec-44a7-9f08-8c359a951e02">
