### PR TITLE
Add missing model.eval() in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ model = ColPali.from_pretrained(
     model_name,
     torch_dtype=torch.bfloat16,
     device_map="cuda:0",  # or "mps" if on Apple Silicon
-)
+).eval()
 
 processor = ColPaliProcessor.from_pretrained(model_name)
 

--- a/tests/models/paligemma/colpali/test_colpali_e2e.py
+++ b/tests/models/paligemma/colpali/test_colpali_e2e.py
@@ -22,7 +22,7 @@ def test_e2e_colpali(colpali_model_name: str):
             torch_dtype=torch.bfloat16,
             device_map=get_torch_device("auto"),
         ),
-    )
+    ).eval()
 
     try:
         processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(colpali_model_name))

--- a/tests/models/paligemma/colpali/test_modeling_colpali.py
+++ b/tests/models/paligemma/colpali/test_modeling_colpali.py
@@ -27,7 +27,7 @@ def colpali_from_pretrained(colpali_model_name: str) -> Generator[ColPali, None,
             colpali_model_name,
             torch_dtype=torch.bfloat16,
             device_map=device,
-        ),
+        ).eval(),
     )
     tear_down_torch()
 


### PR DESCRIPTION
## Description

### Changed
- Add missing `model.eval()` in README

### Fixed

- Add missing `model.eval()` in tests