### PR TITLE
Remove dummy image from ColPaliProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ### Added
-### Changed
-### Fixed
 
+### Changed
+
+- Remove dummy image from `ColPaliProcessor.process_queries`
+
+### Fixed
 
 ## [0.3.1] - 2024-09-27
 


### PR DESCRIPTION
## Features

### Changed

- Remove dummy image from `ColPaliProcessor.process_queries`

### Test

The following code was run from `main`'s head i.e. https://github.com/illuin-tech/colpali/commit/7f53f53ed005cfbafd2640ca7705a6297a97971f.

```python
from typing import List, cast

import torch

from colpali_engine.models import ColPaliProcessor
from colpali_engine.utils.torch_utils import get_torch_device
model_name = "vidore/colpali-v1.2"

device = get_torch_device("auto")
print(f"Using device: {device}")

# Load the processor
processor = cast(ColPaliProcessor, ColPaliProcessor.from_pretrained(model_name))
queries = [
    "Attention is all you need",
    "The quick brown fox jumps over the lazy dog",
    "Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
]
batch_query = processor.process_queries(queries).to(device)

def process_query_new(queries: List[str], suffix=None):
    if suffix is None:
        suffix = "<pad>" * 10
    texts_query: List[str] = []

    for query in queries:
        query = processor.tokenizer.bos_token + f"Question: {query}"
        query += suffix  # add suffix (pad tokens)
        texts_query.append(query)

    input_strings = [f"{sample}\n" for sample in texts_query]

    batch_query = processor.tokenizer(
        input_strings,
        text_pair=None,
        return_token_type_ids=False,
        return_tensors="pt",
        padding="longest",
        max_length=50,
    )

    return batch_query

batch_query_new = process_query_new(queries).to(device)

for key, value in batch_query.items():
    assert torch.allclose(batch_query_new[key], value)
```