### PR TITLE
Fix typing for inputs for `processor.score_multi_vector` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ## Added
+
 - Added support for Idefics3 (and SmolVLM)
 
+### Fixed
+
+- Fix typing for `processor.score_multi_vector` (allow for both list and tensor inputs). This does not change how the scores are computed.
 
 ## [0.3.4] - 2024-11-07
 
 ### Added
+
 - General `CorpusQueryCollator` for BEIR style dataset training or hard negative training. This deprecates `HardNegCollator` but all changes to the training loop are made for a seemless update.
 
-
 ### Changed
+
 - Updates BiPali config files
 - Removed query augmentation tokens from BiQwen2Processor
 - Modified XQwen2Processor to place `<|endoftext|>` token at the end of the document prompt (non-breaking for ColQwen but helps BiQwen).
 - Removed `add_suffix` in the VisualRetrieverCollator and let the `suffix` be added in the individual processors.
 - Changed the incorrect `<pad>` token to `<|endoftext|>` fo query augmentation `ColQwen2Processor`. Note that previous models were trained with `<|endoftext|>` so this is simply a non-breaking inference upgrade patch.
-
 
 ## [0.3.3] - 2024-10-29
 

--- a/colpali_engine/utils/processing_utils.py
+++ b/colpali_engine/utils/processing_utils.py
@@ -66,13 +66,32 @@ class BaseVisualRetrieverProcessor(ABC):
 
     @staticmethod
     def score_multi_vector(
-        qs: List[torch.Tensor],
-        ps: List[torch.Tensor],
+        qs: Union[torch.Tensor, List[torch.Tensor]],
+        ps: Union[torch.Tensor, List[torch.Tensor]],
         batch_size: int = 128,
         device: Optional[Union[str, torch.device]] = None,
     ) -> torch.Tensor:
         """
-        Compute the MaxSim score (ColBERT-like) for the given multi-vector query and passage embeddings.
+        Compute the late-interaction/MaxSim score (ColBERT-like) for the given multi-vector
+        query embeddings (`qs`) and passage embeddings (`ps`). For ColPali, a passage is the
+        image of a document page.
+
+        Because the embedding tensors are multi-vector and can thus have different shapes, they
+        should be fed as:
+        (1) a list of tensors, where the i-th tensor is of shape (sequence_length_i, embedding_dim)
+        (2) a single tensor of shape (n_passages, max_sequence_length, embedding_dim) -> usually
+            obtained by padding the list of tensors.
+
+        Args:
+            qs (`Union[torch.Tensor, List[torch.Tensor]`): Query embeddings.
+            ps (`Union[torch.Tensor, List[torch.Tensor]`): Passage embeddings.
+            batch_size (`int`, *optional*, defaults to 128): Batch size for computing scores.
+            device (`Union[str, torch.device]`, *optional*): Device to use for computation. If not
+                provided, uses `get_torch_device("auto")`.
+
+        Returns:
+            `torch.Tensor`: A tensor of shape `(n_queries, n_passages)` containing the scores. The score
+            tensor is saved on the "cpu" device.
         """
         device = device or get_torch_device("auto")
 

--- a/tests/utils/test_processing_utils.py
+++ b/tests/utils/test_processing_utils.py
@@ -5,6 +5,8 @@ import torch
 
 from colpali_engine.utils.processing_utils import BaseVisualRetrieverProcessor
 
+EMBEDDING_DIM = 32
+
 
 @pytest.fixture
 @patch.multiple(BaseVisualRetrieverProcessor, __abstractmethods__=set())
@@ -13,14 +15,30 @@ def processor() -> BaseVisualRetrieverProcessor:
 
 
 def test_score_single_vector_embeddings(processor: BaseVisualRetrieverProcessor):
-    qs = [torch.randn(128) for _ in range(10)]
-    ps = [torch.randn(128) for _ in range(10)]
+    qs = [torch.randn(EMBEDDING_DIM) for _ in range(4)]
+    ps = [torch.randn(EMBEDDING_DIM) for _ in range(8)]
     scores = processor.score_single_vector(qs, ps)
     assert scores.shape == (len(qs), len(ps))
 
 
 def test_score_multi_vector_embeddings(processor: BaseVisualRetrieverProcessor):
-    qs = [torch.randn(10, 128) for _ in range(10)]
-    ps = [torch.randn(42, 128) for _ in range(10)]
-    scores = processor.score_multi_vector(qs, ps)
-    assert scores.shape == (len(qs), len(ps))
+    # Score from list input
+    qs = [
+        torch.randn(2, EMBEDDING_DIM),
+        torch.randn(4, EMBEDDING_DIM),
+    ]
+    ps = [
+        torch.randn(8, EMBEDDING_DIM),
+        torch.randn(4, EMBEDDING_DIM),
+        torch.randn(16, EMBEDDING_DIM),
+    ]
+    scores_from_list_input = processor.score_multi_vector(qs, ps)
+    assert scores_from_list_input.shape == (len(qs), len(ps))
+
+    # Score from tensor input
+    qs_padded = torch.nn.utils.rnn.pad_sequence(qs, batch_first=True)
+    ps_padded = torch.nn.utils.rnn.pad_sequence(ps, batch_first=True)
+    scores_from_tensor = processor.score_multi_vector(qs_padded, ps_padded)
+    assert scores_from_tensor.shape == (len(qs), len(ps))
+
+    assert torch.allclose(scores_from_list_input, scores_from_tensor), "Scores from list and tensor inputs should match"


### PR DESCRIPTION
## Description

Sometimes, the user already has padded the embeddings he/she wants to score using the processor's `score_multi_vector` method. Thus, we want to allow him/her to feed this padded and stacked tensor to the latter method, without the need of using `torch.unbind`.

Actually this is already possible today, but the typing for the `processor.score_multi_vector` is incorrect.

This PR fixes the typing, but does not change how the scores are computed.

## Feature

### Changed

- Fix typing for `processor.score_multi_vector` (allow for both list and tensor inputs). This does not change how the scores are computed.