### PR TITLE
Fix `tear_down_torch` when used on a non-MPS machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix typing for `processor.score_multi_vector` (allow for both list and tensor inputs). This does not change how the scores are computed.
+- Fix `tear_down_torch` when used on a non-MPS machine
 
 ## [0.3.4] - 2024-11-07
 

--- a/colpali_engine/utils/torch_utils.py
+++ b/colpali_engine/utils/torch_utils.py
@@ -37,8 +37,10 @@ def tear_down_torch():
     Clears GPU cache for both CUDA and MPS.
     """
     gc.collect()
-    torch.cuda.empty_cache()
-    torch.mps.empty_cache()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
 
 
 class ListDataset(Dataset[T]):


### PR DESCRIPTION
## Description

Fix `tear_down_torch` when used on a non-MPS machine.