### PR TITLE
Fix deps mismatch in `colpali-engine[train]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## [0.3.8] - 2025-01-29
+
+### Fixed
+
+- Fix peft version in `colpali-engine[train]`
+- Loosen upper bound for `accelerate`
 
 ### Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 dependencies = [
     "GPUtil",
     "numpy",
-    "peft>=0.11.0",
+    "peft>=0.14.0,<0.15.0",
     "pillow>=10.0.0",
     "requests",
     "torch>=2.2.0",
@@ -44,12 +44,11 @@ dependencies = [
 
 [project.optional-dependencies]
 train = [
-    "accelerate>=0.34.0,<1.1.0",
+    "accelerate>=0.34.0,<1.4.0",
     "bitsandbytes",
     "configue>=5.0.0",
     "datasets>=2.19.1",
     "mteb>=1.16.3,<1.17.0",
-    "peft>=0.11.0,<0.12.0",
     "pillow>=10.0.0,<11.1.0",
     "typer>=0.15.1",
 ]


### PR DESCRIPTION
## Description

Fix deps mismatch in `colpali-engine[train]`.

## Features

### Fixed

- Fix peft version in `colpali-engine[train]`
- Loosen upper bound for `accelerate`
