### PR TITLE
Fix token pooling when pool factor equals 1

### DIFF
--- a/colpali_engine/compression/token_pooling.py
+++ b/colpali_engine/compression/token_pooling.py
@@ -57,12 +57,10 @@ class HierarchicalTokenPooler(BaseTokenPooler):
         """
         Return the pooled embeddings.
 
-        The `embeddings` input can be one of the following:
-        - A list of 2D tensors if the embeddings' sequence lengths are different.
-        - A 3D tensor if the embeddings have the same length (no padding).
-
         Args:
-            embeddings: A tensor of shape (token_length, embedding_dim) or (batch_size, token_length, embedding_dim).
+            embeddings: A list of 2D tensors (token_length, embedding_dim) where each tensor can have its own
+                        token_length, or a 3D tensor of shape (batch_size, token_length, embedding_dim) without
+                        padding.
             return_dict: Whether or not to return a `TokenPoolingOutput` object (with the cluster id to token indices
                          mapping) instead of just the pooled embeddings.
 

--- a/colpali_engine/compression/token_pooling.py
+++ b/colpali_engine/compression/token_pooling.py
@@ -97,6 +97,14 @@ class HierarchicalTokenPooler(BaseTokenPooler):
         if token_length == 1:
             raise ValueError("The input tensor must have more than one token.")
 
+        if self.pool_factor == 1:
+            if not return_dict:
+                return embedding
+            return TokenPoolingOutput(
+                pooled_embedding=embedding,
+                cluster_id_to_indices={0: (torch.arange(token_length),)},
+            )
+
         list_pooled_embeddings: List[torch.Tensor] = []
 
         similarities = torch.mm(embedding, embedding.t())

--- a/colpali_engine/compression/token_pooling.py
+++ b/colpali_engine/compression/token_pooling.py
@@ -51,7 +51,7 @@ class HierarchicalTokenPooler(BaseTokenPooler):
 
     def pool_embeddings(
         self,
-        embeddings: Union[torch.Tensor, List[torch.Tensor]],
+        embeddings: Union[List[torch.Tensor], torch.Tensor],
         return_dict: bool = False,
     ) -> List[Union[torch.Tensor, TokenPoolingOutput]]:
         """
@@ -69,12 +69,14 @@ class HierarchicalTokenPooler(BaseTokenPooler):
         Returns:
             A list of pooled embeddings or `PooledOutput` objects.
         """
-        if isinstance(embeddings, torch.Tensor) and embeddings.dim() == 2:
-            return [self._pool_single_embedding(embeddings, return_dict=return_dict)]
-        elif isinstance(embeddings, list) or embeddings.dim() == 3:
+        if isinstance(embeddings, list) and not embeddings:
+            return []
+        elif (isinstance(embeddings, list) and embeddings[0].dim() == 2) or (
+            isinstance(embeddings, torch.Tensor) and embeddings.dim() == 3
+        ):
             return [self._pool_single_embedding(batch_emb, return_dict) for batch_emb in embeddings]
         else:
-            raise ValueError("The input tensor must be a list of 2D tensors or a 2D/3D tensor.")
+            raise ValueError("The input tensor must be a list of 2D tensors or a 3D tensor.")
 
     def _pool_single_embedding(
         self,

--- a/tests/compression/test_token_pooling.py
+++ b/tests/compression/test_token_pooling.py
@@ -5,7 +5,7 @@ from colpali_engine.compression.token_pooling import HierarchicalTokenPooler, To
 
 
 @pytest.fixture
-def sample_embeddings() -> torch.Tensor:
+def sample_embedding() -> torch.Tensor:
     return torch.tensor(
         [
             [1.0, 0.0, 0.0],
@@ -16,112 +16,115 @@ def sample_embeddings() -> torch.Tensor:
             [1.0, 0.0, 0.0],
         ],
         dtype=torch.float32,
-    )
+    )  # (6, 3)
 
 
-def test_hierarchical_embedding_pooler_initialization():
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    assert pooler.pool_factor == 2
+class TestHierarchicalTokenPooler:
+    def test_hierarchical_embedding_pooler_initialization(self):
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        assert pooler.pool_factor == 2
 
+    def selftest_hierarchical_embedding_pooler_output_shape(self, sample_embedding: torch.Tensor):
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        outputs = pooler.pool_embeddings([sample_embedding], return_dict=True)
 
-def test_hierarchical_embedding_pooler_output_shape(sample_embeddings: torch.Tensor):
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    outputs = pooler.pool_embeddings(sample_embeddings, return_dict=True)
-
-    assert isinstance(outputs, list)
-    assert len(outputs) == 1
-    assert isinstance(outputs[0], TokenPoolingOutput)
-    assert outputs[0].pooled_embedding.shape[1] == sample_embeddings.shape[1]
-    assert outputs[0].pooled_embedding.shape[0] <= len(outputs[0].cluster_id_to_indices)
-
-
-def test_hierarchical_embedding_pooler_without_dict_output(sample_embeddings: torch.Tensor):
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    outputs = pooler.pool_embeddings(sample_embeddings, return_dict=False)
-
-    assert isinstance(outputs, list)
-    assert len(outputs) == 1
-    assert isinstance(outputs[0], torch.Tensor)
-
-    expected_pooled_embeddings = torch.tensor(
-        [
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ],
-        dtype=torch.float32,
-    )
-    assert torch.allclose(outputs[0], expected_pooled_embeddings)
-
-
-def test_hierarchical_embedding_pooler_output_values(sample_embeddings: torch.Tensor):
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    outputs = pooler.pool_embeddings(sample_embeddings, return_dict=True)
-
-    expected_pooled_embeddings = torch.tensor(
-        [
-            [1.0, 0.0, 0.0],
-            [0.0, 1.0, 0.0],
-            [0.0, 0.0, 1.0],
-        ],
-        dtype=torch.float32,
-    )
-    expected_cluster_id_to_indices = {
-        0: (torch.tensor([0, 3, 4, 5]),),
-        1: (torch.tensor([1]),),
-        2: (torch.tensor([2]),),
-    }
-
-    assert torch.allclose(outputs[0].pooled_embedding, expected_pooled_embeddings)
-    assert all(
-        [
-            torch.allclose(outputs[0].cluster_id_to_indices[cluster_id][0], expected_cluster_indices[0])
-            for cluster_id, expected_cluster_indices in expected_cluster_id_to_indices.items()
-        ]
-    )
-
-
-def test_hierarchical_embedding_pooler_with_different_pool_factors(sample_embeddings: torch.Tensor):
-    for pool_factor in [1, 2, 3]:
-        pooler = HierarchicalTokenPooler(pool_factor=pool_factor)
-        outputs = pooler.pool_embeddings(sample_embeddings, return_dict=True)
-        expected_num_clusters = (sample_embeddings.shape[0] + pool_factor - 1) // pool_factor
-        assert outputs[0].pooled_embedding.shape[0] <= expected_num_clusters
+        assert isinstance(outputs, list)
+        assert len(outputs) == 1
+        assert isinstance(outputs[0], TokenPoolingOutput)
+        assert outputs[0].pooled_embedding.shape[1] == sample_embedding.shape[1]
         assert outputs[0].pooled_embedding.shape[0] <= len(outputs[0].cluster_id_to_indices)
 
+    def test_hierarchical_embedding_pooler_without_dict_output(self, sample_embedding: torch.Tensor):
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        outputs = pooler.pool_embeddings([sample_embedding], return_dict=False)
 
-def test_hierarchical_embedding_pooler_should_raise_error_with_single_token():
-    single_token_embeddings = torch.rand(1, 768)
-    pooler = HierarchicalTokenPooler(pool_factor=2)
+        assert isinstance(outputs, list)
+        assert len(outputs) == 1
+        assert isinstance(outputs[0], torch.Tensor)
 
-    with pytest.raises(ValueError):
-        pooler.pool_embeddings(single_token_embeddings, return_dict=True)
+        expected_pooled_embeddings = torch.tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=torch.float32,
+        )
+        assert torch.allclose(outputs[0], expected_pooled_embeddings)
 
+    def test_hierarchical_embedding_pooler_with_dict_outputs(self, sample_embedding: torch.Tensor):
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        outputs = pooler.pool_embeddings([sample_embedding], return_dict=True)
 
-def test_hierarchical_embedding_pooler_batched_input():
-    batch_embeddings = torch.rand(3, 10, 768)
+        expected_pooled_embeddings = torch.tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=torch.float32,
+        )
+        expected_cluster_id_to_indices = {
+            0: (torch.tensor([0, 3, 4, 5]),),
+            1: (torch.tensor([1]),),
+            2: (torch.tensor([2]),),
+        }
 
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    outputs = pooler.pool_embeddings(batch_embeddings, return_dict=True)
+        assert torch.allclose(outputs[0].pooled_embedding, expected_pooled_embeddings)
+        assert all(
+            [
+                torch.allclose(outputs[0].cluster_id_to_indices[cluster_id][0], expected_cluster_indices[0])
+                for cluster_id, expected_cluster_indices in expected_cluster_id_to_indices.items()
+            ]
+        )
 
-    assert len(outputs) == 3
-    for output in outputs:
-        assert isinstance(output, TokenPoolingOutput)
-        assert output.pooled_embedding.shape[1] == 768
-        assert output.pooled_embedding.shape[0] <= 5
+    def test_hierarchical_embedding_pooler_with_pool_factor_1(self, sample_embedding: torch.Tensor):
+        pooler = HierarchicalTokenPooler(pool_factor=1)
+        outputs = pooler.pool_embeddings([sample_embedding], return_dict=True)
 
+        assert outputs[0].pooled_embedding.shape == sample_embedding.shape
+        assert torch.allclose(outputs[0].pooled_embedding, sample_embedding)
 
-def test_hierarchical_embedding_pooler_list_input():
-    list_embeddings = [
-        torch.rand(10, 768),
-        torch.rand(15, 768),
-    ]
+    def test_hierarchical_embedding_pooler_with_different_pool_factors(self, sample_embedding: torch.Tensor):
+        for pool_factor in range(1, 6):
+            pooler = HierarchicalTokenPooler(pool_factor=pool_factor)
+            outputs = pooler.pool_embeddings([sample_embedding], return_dict=True)
 
-    pooler = HierarchicalTokenPooler(pool_factor=2)
-    outputs = pooler.pool_embeddings(list_embeddings, return_dict=True)
+            expected_num_clusters = max(sample_embedding.shape[0] // pool_factor, 1)
 
-    assert len(outputs) == len(list_embeddings)
-    for input_embedding, output in zip(list_embeddings, outputs):
-        assert isinstance(output, TokenPoolingOutput)
-        assert output.pooled_embedding.shape[1] == 768
-        assert output.pooled_embedding.shape[0] <= input_embedding.shape[0] // 2
+            assert outputs[0].pooled_embedding.shape[0] == expected_num_clusters
+            assert outputs[0].pooled_embedding.shape[0] <= len(outputs[0].cluster_id_to_indices[0][0])
+
+    def test_hierarchical_embedding_pooler_should_raise_error_with_single_token(self):
+        single_token_embeddings = torch.rand(1, 768)
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+
+        with pytest.raises(ValueError):
+            pooler.pool_embeddings(single_token_embeddings, return_dict=True)
+
+    def test_hierarchical_embedding_pooler_batched_input(self):
+        batch_embeddings = torch.rand(3, 10, 768)
+
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        outputs = pooler.pool_embeddings(batch_embeddings, return_dict=True)
+
+        assert len(outputs) == 3
+        for output in outputs:
+            assert isinstance(output, TokenPoolingOutput)
+            assert output.pooled_embedding.shape[1] == 768
+            assert output.pooled_embedding.shape[0] <= 5
+
+    def test_hierarchical_embedding_pooler_list_input(self):
+        list_embeddings = [
+            torch.rand(10, 768),
+            torch.rand(15, 768),
+        ]
+
+        pooler = HierarchicalTokenPooler(pool_factor=2)
+        outputs = pooler.pool_embeddings(list_embeddings, return_dict=True)
+
+        assert len(outputs) == len(list_embeddings)
+        for input_embedding, output in zip(list_embeddings, outputs):
+            assert isinstance(output, TokenPoolingOutput)
+            assert output.pooled_embedding.shape[1] == 768
+            assert output.pooled_embedding.shape[0] <= input_embedding.shape[0] // 2


### PR DESCRIPTION
## Description

When `pool_factor` equals 1, make sure the returned tensor is the same as the input one.