### PR TITLE
Remove padding value option from token pooler

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ import torch
 
 from colpali_engine.compression.token_pooling import HierarchicalTokenPooler
 
-# Dummy embeddings
+# Dummy multivector embeddings
 list_embeddings = [
     torch.rand(10, 768),
     torch.rand(20, 768),

--- a/colpali_engine/compression/token_pooling.py
+++ b/colpali_engine/compression/token_pooling.py
@@ -60,7 +60,6 @@ class HierarchicalTokenPooler(BaseTokenPooler):
         embeddings: Union[List[torch.Tensor], torch.Tensor],
         return_dict: bool = False,
         padding: bool = False,
-        padding_value: float = 0.0,
         padding_side: str = "left",
         num_workers: Optional[int] = None,
     ) -> Union[Union[torch.Tensor, List[torch.Tensor]], TokenPoolingOutput]:
@@ -99,7 +98,7 @@ class HierarchicalTokenPooler(BaseTokenPooler):
             if padding:
                 embeddings = unbind_padded_multivector_embeddings(
                     embeddings,
-                    padding_value=padding_value,
+                    padding_value=0.0,
                     padding_side=padding_side,
                 )
             else:
@@ -119,7 +118,7 @@ class HierarchicalTokenPooler(BaseTokenPooler):
             pooled_embeddings = torch.nn.utils.rnn.pad_sequence(
                 pooled_embeddings,
                 batch_first=True,
-                padding_value=padding_value,
+                padding_value=0.0,
                 padding_side=padding_side,
             )
 

--- a/colpali_engine/compression/token_pooling.py
+++ b/colpali_engine/compression/token_pooling.py
@@ -45,6 +45,28 @@ class BaseTokenPooler(ABC):
 class HierarchicalTokenPooler(BaseTokenPooler):
     """
     Hierarchical token pooling of multi-vector embeddings based on the similarity between token embeddings.
+
+    Example with a list of 2D tensors:
+
+    ```python
+    list_embeddings = [torch.rand(10, 768), torch.rand(20, 768)]
+    pooler = HierarchicalTokenPooler(pool_factor=2)
+    outputs = pooler.pool_embeddings(list_embeddings)
+    ```
+
+    Example with a 0-padded 3D tensor:
+
+    ```python
+    list_embeddings = [torch.rand(10, 768), torch.rand(20, 768)]
+    padded_embeddings = torch.nn.utils.rnn.pad_sequence(
+            list_embeddings,
+            batch_first=True,
+            padding_value=0.0,
+            padding_side="left",
+        )
+    pooler = HierarchicalTokenPooler(pool_factor=2)
+    outputs = pooler.pool_embeddings(list_embeddings, padding=True, padding_side="left")
+    ```
     """
 
     def __init__(self, pool_factor: int):
@@ -68,19 +90,18 @@ class HierarchicalTokenPooler(BaseTokenPooler):
 
         Args:
             embeddings: A list of 2D tensors (token_length, embedding_dim) where each tensor can have its own token
-                        length, or a 3D tensor of shape (batch_size, token_length, embedding_dim) with padding.
+                        length, or a 3D tensor of shape (batch_size, token_length, embedding_dim) with 0-padding.
             return_dict: Whether or not to return a `TokenPoolingOutput` object (with the cluster id to token indices
                          mapping) instead of just the pooled embeddings.
             padding: Whether or not to unbind the padded 3D tensor into a list of 2D tensors. Does nothing if the input
                      is a list of 2D tensors.
-            padding_value: The padding value used in the 3D tensor.
             padding_side: The side where the padding was applied in the 3D tensor.
 
         Returns:
             If the `embeddings` input is:
             - A list of 2D tensors: Returns a list of 2D tensors (token_length, embedding_dim) where each tensor can
                                     have its own token_length.
-            - A 3D tensor: A 3D tensor of shape (batch_size, token_length, embedding_dim) with padding.
+            - A 3D tensor: A 3D tensor of shape (batch_size, token_length, embedding_dim) with 0-padding.
 
             If `return_dict` is True, the pooled embeddings are returned within a `TokenPoolingOutput` object, along
             with the cluster id to token indices mapping.

--- a/colpali_engine/utils/torch_utils.py
+++ b/colpali_engine/utils/torch_utils.py
@@ -60,7 +60,7 @@ def unbind_padded_multivector_embeddings(
     padding_side: str = "left",
 ) -> List[torch.Tensor]:
     """
-    Removes padding elements from a batch of embeddings.
+    Removes padding elements from a batch of multivector embeddings.
 
     Args:
         embeddings (torch.Tensor): A tensor of shape (batch_size, seq_length, dim) with padding.

--- a/tests/compression/test_token_pooling.py
+++ b/tests/compression/test_token_pooling.py
@@ -171,7 +171,6 @@ class TestHierarchicalTokenPooler:
             padded_embeddings,
             return_dict=False,
             padding=True,
-            padding_value=0.0,
             padding_side="left",
         )
 


### PR DESCRIPTION
## Description

Remove padding value option from token pooler, because it should padding value should always be 0 for proper late interaction computation on batched embedding tensors.