### PR TITLE
Fix min/max pixels not being used in `ColQwen2Processor`

### DIFF
--- a/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/processing_colqwen2.py
@@ -44,6 +44,9 @@ class ColQwen2Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):
         self.min_pixels = 4 * 28 * 28
         self.max_pixels = self.max_num_visual_tokens * 28 * 28
 
+        self.image_processor.min_pixels = self.min_pixels
+        self.image_processor.max_pixels = self.max_pixels
+
     def process_images(self, images: List[Image.Image]) -> BatchFeature:
         """
         Process images for ColQwen2.


### PR DESCRIPTION
## Description

Fix `min_pixels`/`max_pixels` not being used in `ColQwen2Processor`. Follow-up of https://github.com/illuin-tech/colpali/pull/205.

Feeds all common attributes to the `self.image_processor`. See `min_pixels`/`max_pixels`  in the following init in `Qwen2VLImageProcessor` for reference:

```python
    def __init__(
        self,
        do_resize: bool = True,
        resample: PILImageResampling = PILImageResampling.BICUBIC,
        do_rescale: bool = True,
        rescale_factor: Union[int, float] = 1 / 255,
        do_normalize: bool = True,
        image_mean: Optional[Union[float, List[float]]] = None,
        image_std: Optional[Union[float, List[float]]] = None,
        do_convert_rgb: bool = True,
        min_pixels: int = 56 * 56,
        max_pixels: int = 28 * 28 * 1280,
        patch_size: int = 14,
        temporal_patch_size: int = 2,
        merge_size: int = 2,
        **kwargs,
    ) -> None:
```