### PR TITLE
fix min/max pixels for colqwen2_5

### DIFF
--- a/colpali_engine/models/qwen2_5/colqwen2_5/processing_colqwen2_5.py
+++ b/colpali_engine/models/qwen2_5/colqwen2_5/processing_colqwen2_5.py
@@ -44,6 +44,9 @@ class ColQwen2_5_Processor(BaseVisualRetrieverProcessor, Qwen2VLProcessor):  # n
         self.min_pixels = 4 * 28 * 28
         self.max_pixels = self.max_num_visual_tokens * 28 * 28
 
+        self.image_processor.min_pixels = self.min_pixels
+        self.image_processor.max_pixels = self.max_pixels
+
     def process_images(self, images: List[Image.Image]) -> BatchFeature:
         """
         Process images for ColQwen2.5.


### PR DESCRIPTION
Same as colqwen2 in #205 , the min/max pixels need to be set through the image_processor for the colqwen2_5