### PR TITLE
fix: downcast float64 and int64 to float32 and int32 on MPS devices to ensure compatibility when using Idefics3

### DIFF
--- a/colpali_engine/models/idefics3/colidefics3/processing_colidefics3.py
+++ b/colpali_engine/models/idefics3/colidefics3/processing_colidefics3.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, List, Optional, Tuple, Union
+from typing import ClassVar, Dict, List, Optional, Tuple, Union
 
 import torch
 from PIL import Image
@@ -23,6 +23,16 @@ class ColIdefics3Processor(BaseVisualRetrieverProcessor, Idefics3Processor):
     @property
     def image_token_id(self) -> int:
         return self.tokenizer.convert_tokens_to_ids(self.image_token)
+
+    @staticmethod
+    def reduce_tensor_type(tensor_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        for key, value in tensor_dict.items():
+            if isinstance(value, torch.Tensor):
+                if value.dtype == torch.int64:
+                    tensor_dict[key] = value.to(torch.int32)
+                elif value.dtype == torch.float64:
+                    tensor_dict[key] = value.to(torch.float32)
+        return tensor_dict
 
     def process_images(
         self,
@@ -53,6 +63,8 @@ class ColIdefics3Processor(BaseVisualRetrieverProcessor, Idefics3Processor):
             return_tensors="pt",
             padding="longest",
         )
+        if torch.backends.mps.is_available():
+            batch_doc = self.reduce_tensor_type(batch_doc)
         return batch_doc
 
     def process_queries(


### PR DESCRIPTION
When using Idefics3 type models like SmolVLM, inputs are encoded in float64 and int64 which are not supported by MPS.
Here are the errors that I got when I tried training SmolVLM on MPS :
```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework doesn't support float64. Please use float32 instead.
```

I downcast ints and floats to ensure compatibility. This shouldn't affect much the output of Idefics as the model's ids can all be represented in int32 and we don't need a float64 precision to train our models.