### PR TITLE
Bump minimum PyTorch version to 2.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,8 +60,6 @@ interpretability = [
     "seaborn>=0.13.2,<1.0.0",
 ]
 
-mps = ["torch>=2.5.0,<2.6.0"]
-
 dev = ["pytest>=8.0.0", "ruff>=0.4.0"]
 
 all = [


### PR DESCRIPTION
## Description

- Bump minimum PyTorch version to 2.5.0.
- Remove unnecessary `mps` dep group (now redundant after the PyTorch bump)

