### PR TITLE
fix: fix dataset batch sampler

### DIFF
--- a/colpali_engine/data/sampler.py
+++ b/colpali_engine/data/sampler.py
@@ -23,12 +23,6 @@ class SingleDatasetBatchSampler(BatchSampler):
         drop_last: bool = True,
         generator: Optional[torch.Generator] = None,
     ):
-        # round down each dataset if not divible by global batch size
-        for i in range(len(datasets)):
-            if len(datasets[i]) % global_batch_size != 0:
-                total_samples = (len(datasets[i]) // global_batch_size) * global_batch_size
-                datasets[i] = datasets[i].take(total_samples)
-
         self.datasets = datasets
         self.global_batch_size = global_batch_size
         self.drop_last = drop_last

--- a/colpali_engine/trainer/contrastive_trainer.py
+++ b/colpali_engine/trainer/contrastive_trainer.py
@@ -23,6 +23,14 @@ class ContrastiveTrainer(Trainer):
         else:
             dataset_list = None
 
+        if isinstance(dataset_list, list):
+            # round down each dataset if not divible by global batch size
+            batch_size = kwargs["args"].train_batch_size
+            for i in range(len(dataset_list)):
+                if len(dataset_list[i]) % batch_size != 0:
+                    total_samples = (len(dataset_list[i]) // batch_size) * batch_size
+                    dataset_list[i] = dataset_list[i].take(total_samples)
+
         if dataset_list is not None:
             kwargs["train_dataset"] = ConcatDataset(dataset_list)
 


### PR DESCRIPTION
When using the `SingleDatasetBatchSampler`, I encountered a bug where batches were unintentionally mixing samples from different datasets. This happened because each dataset is truncated during the initialization of `SingleDatasetBatchSampler`, but the sampler ultimately uses the dataset associated with the trainer, which remains untruncated.

I discovered this issue while training on two separate datasets—one containing only images and the other only text. Despite this clear separation, some batches ended up containing both images and text, indicating that samples from both datasets were being combined incorrectly.