### PR TITLE
Update torch version constraint in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pillow>=10.0.0",
     "requests",
     "scipy",
-    "torch>=2.5.0,<2.8.0",
+    "torch>=2.5.0,<2.9.0",
     "torchvision",
     "transformers>=4.53.1,<4.54.0",
 ]


### PR DESCRIPTION
Allow torch 2.8 for colpali-engine