### PR TITLE
fix: load embed_tokens and norm for ColQwen2/ColQwen2_5 on transformers 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix ModernVBERT wrappers to rely on the upstream Hugging Face implementation and keep checkpoint key conversion mapping working with current Transformers v5 loading.
 - Fix `ContrastiveTrainer._get_train_sampler` to accept the dataset argument that Transformers v5 passes positionally (single-dataset training crashed with a `TypeError` at dataloader build).
 - Fix `ContrastiveTrainer` to prime `query_prefix`/`pos_prefix`/`neg_prefix` from the collator in `__init__` (single-dataset training crashed with an `AttributeError` in `compute_loss`, as only the multi-dataset path set them).
+- Fix `ColQwen2`/`ColQwen2_5` checkpoint conversion to remap `model.embed_tokens` and `model.norm` to the `language_model.*` layout used by Transformers v5, so these weights are no longer silently dropped and randomly re-initialized when loading from Qwen2-VL checkpoints.
 
 ## [0.3.14] - 2026-02-24
 

--- a/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
+++ b/colpali_engine/models/qwen2/colqwen2/modeling_colqwen2.py
@@ -21,6 +21,8 @@ class ColQwen2(Qwen2VLModel):
     _checkpoint_conversion_mapping = {
         r"^base_model\.model\.custom_text_proj": "custom_text_proj",
         r"^model\.layers": "language_model.layers",
+        r"^model\.embed_tokens": "language_model.embed_tokens",
+        r"^model\.norm": "language_model.norm",
     }
 
     def __init__(self, config: Qwen2VLConfig, mask_non_image_embeddings: bool = False):

--- a/colpali_engine/models/qwen2_5/colqwen2_5/modeling_colqwen2_5.py
+++ b/colpali_engine/models/qwen2_5/colqwen2_5/modeling_colqwen2_5.py
@@ -22,6 +22,8 @@ class ColQwen2_5(Qwen2_5_VLModel):  # noqa: N801
     _checkpoint_conversion_mapping = {
         r"^base_model\.model\.custom_text_proj": "custom_text_proj",
         r"^model\.layers": "language_model.layers",
+        r"^model\.embed_tokens": "language_model.embed_tokens",
+        r"^model\.norm": "language_model.norm",
     }
 
     def __init__(self, config: Qwen2_5_VLConfig, mask_non_image_embeddings: bool = False):


### PR DESCRIPTION
## Summary

Fixes #413.

On `transformers` 5.x, `Qwen2VLModel.__init__` nests the text backbone under `language_model`, so the expected keys are `language_model.embed_tokens`, `language_model.layers.*`, `language_model.norm`. Released Qwen2-VL checkpoints store these as `model.embed_tokens`, `model.layers.*`, `model.norm`.

`ColQwen2._checkpoint_conversion_mapping` only remapped `model.layers`, so `embed_tokens` and `norm` were silently dropped and randomly re-initialized when loading from a Qwen2-VL checkpoint. `ColQwen2_5` had the same incomplete mapping and was affected identically.

## Changes

Add the missing rules to both `modeling_colqwen2.py` and `modeling_colqwen2_5.py`:

```python
_checkpoint_conversion_mapping = {
    r"^base_model\.model\.custom_text_proj": "custom_text_proj",
    r"^model\.layers": "language_model.layers",
    r"^model\.embed_tokens": "language_model.embed_tokens",
    r"^model\.norm": "language_model.norm",
}
```

This is backward-compatible: the rules only match keys starting with `model.`, so checkpoints already saved in the `language_model.*` layout are unaffected.

## Result

Before, `language_model.embed_tokens.weight` and `language_model.norm.weight` were reported MISSING while their source tensors were UNEXPECTED. After the fix only the expected `custom_text_proj.{weight,bias}` (the ColBERT projection head trained from scratch) remain MISSING.