### PR TITLE
feat: wire fast-plaid as the `plaid` optional dependency (#335)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ with torch.no_grad():
 scores = processor.score_multi_vector(query_embeddings, image_embeddings)
 ```
 
-We now support `fast-plaid` experimentally to make matching quicker for larger corpus sizes:
+We support `fast-plaid` to make matching quicker for larger corpus sizes. Install it with the `plaid` extra:
 
 ```python
-# !pip install --no-deps fast-plaid fastkmeans
+# !pip install "colpali-engine[plaid]"
 
 # Process the inputs by batches of 4
 dataloader = DataLoader(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ interpretability = [
 
 lik = ["late-interaction-kernels>=0.4.1,<0.5.0"]
 
+plaid = ["fast-plaid>=1.4.7,<2.0.0", "fastkmeans"]
+
 dev = ["pytest>=8.0.0", "ruff>=0.4.0"]
 
 all = [
     "colpali-engine[dev]",
     "colpali-engine[interpretability]",
     "colpali-engine[lik]",
+    "colpali-engine[plaid]",
     "colpali-engine[train]",
 ]
 


### PR DESCRIPTION
**Closes #335.**

In #335, @ManuelFay noted the issues that previously blocked integrating `fast-plaid`
are now fixed and suggested wiring it in directly:

> we can just add the dep in the pyproject.toml and modify the readme!

This does exactly that (the volunteer who offered to take it went quiet a while back,
so I picked it up).

## Changes
- **`pyproject.toml`** — add a `plaid` optional-dependency group and include it in `all`:
  ```toml
  plaid = ["fast-plaid>=1.4.7,<2.0.0", "fastkmeans"]
  ```
- **`README.md`** — replace the experimental manual install
  (`# !pip install --no-deps fast-plaid fastkmeans`) with the supported extra
  (`pip install "colpali-engine[plaid]"`) and drop the "experimentally" caveat.

## Compatibility
`fast-plaid` 1.4.7.x requires `torch==2.11.0`, which is inside the project's existing
`torch>=2.2.0,<2.12.0` pin, and pulls `fastkmeans==0.5.0` transitively. The PLAID
helpers (`create_plaid_index` / `get_topk_plaid`) already exist in the codebase — this
only wires the install path. Happy to tighten or loosen the version bound if you prefer.

---
*Disclosure: drafted with AI assistance (Claude); reviewed, tested, and submitted by me. The commit carries a `Co-Authored-By` trailer.*
