### PR TITLE
Clean up repository before deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,42 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.18] - 2026-08-22
+
+### Added
+
+- Add the optional `[plaid]` extra (`fast-plaid>=1.4.7,<2.0.0` and `fastkmeans`) for faster matching on larger corpora, and include it in the `[all]` extra.
+
+### Changed
+
+- Extend supported dependency ranges to allow `torch<2.14.0`, `peft<0.21.0`, and `pillow<12.4.0` in the training extra.
+
+### Fixed
+
+- Fix `ColQwen2`/`ColQwen2_5` checkpoint conversion to remap `model.embed_tokens` and `model.norm` to the `language_model.*` layout used by Transformers v5, so these weights are no longer silently dropped and randomly re-initialized when loading from Qwen2-VL checkpoints.
+
+## [0.3.17] - 2026-06-08
+
+### Added
+
+- Add optional `[lik]` extra (`late-interaction-kernels>=0.4.1,<0.5.0`) that routes `score_multi_vector` and the five ColBERT losses through the fused Triton MaxSim kernel on CUDA Ampere+ / Apple Silicon, with a transparent torch fallback elsewhere. `COLPALI_SCORES_BACKEND` selects the backend (mirrors PyLate's `PYLATE_SCORES_BACKEND`): `auto` (default), `torch` (force the fallback), or `lik` (strict; raises when the kernel cannot run).
+
+### Fixed
+
+- Fix `ContrastiveTrainer._get_train_sampler` to accept the dataset argument that Transformers v5 passes positionally (single-dataset training crashed with a `TypeError` at dataloader build).
+- Fix `ContrastiveTrainer` to prime `query_prefix`/`pos_prefix`/`neg_prefix` from the collator in `__init__` (single-dataset training crashed with an `AttributeError` in `compute_loss`, as only the multi-dataset path set them).
+
+## [0.3.16] - 2026-05-12
+
+### Changed
+
+- Extend supported dependency ranges to allow `torch<2.12.0`, `peft<0.20.0`, and `pillow<12.3.0`.
+
+## [0.3.15] - 2026-03-31
+
 ### Added
 
 - Add ColQwen3.5 and BiQwen3.5 support (model + processor). Pretrained checkpoint: [athrael-soju/colqwen3.5-4.5B-v3](https://huggingface.co/athrael-soju/colqwen3.5-4.5B-v3).
-- Add optional `[lik]` extra (`late-interaction-kernels>=0.4.1,<0.5.0`) that routes `score_multi_vector` and the five ColBERT losses through the fused Triton MaxSim kernel on CUDA Ampere+ / Apple Silicon, with a transparent torch fallback elsewhere. `COLPALI_SCORES_BACKEND` selects the backend (mirrors PyLate's `PYLATE_SCORES_BACKEND`): `auto` (default), `torch` (force the fallback), or `lik` (strict; raises when the kernel cannot run).
 
 ### Changed
 
@@ -19,9 +51,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix ModernVBERT wrappers to rely on the upstream Hugging Face implementation and keep checkpoint key conversion mapping working with current Transformers v5 loading.
-- Fix `ContrastiveTrainer._get_train_sampler` to accept the dataset argument that Transformers v5 passes positionally (single-dataset training crashed with a `TypeError` at dataloader build).
-- Fix `ContrastiveTrainer` to prime `query_prefix`/`pos_prefix`/`neg_prefix` from the collator in `__init__` (single-dataset training crashed with an `AttributeError` in `compute_loss`, as only the multi-dataset path set them).
-- Fix `ColQwen2`/`ColQwen2_5` checkpoint conversion to remap `model.embed_tokens` and `model.norm` to the `language_model.*` layout used by Transformers v5, so these weights are no longer silently dropped and randomly re-initialized when loading from Qwen2-VL checkpoints.
 
 ## [0.3.14] - 2026-02-24
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,73 @@ Using ColPali removes the need for potentially complex and brittle layout recogn
 
 ![ColPali Architecture](assets/colpali_architecture.webp)
 
+## ⚠️ ColPali Engine is deprecated
+
+> [!IMPORTANT]
+> `colpali-engine` is now deprecated. The repository and package remain available for research, reproducibility, and existing projects, but we recommend [Sentence Transformers](https://www.sbert.net/) for new projects and production use.
+
+[Sentence Transformers v6](https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0) introduces first-class support for ColPali-style models through `MultiVectorEncoder`. It provides one ecosystem for embedding and retrieval models—including dense bi-encoders and multi-vector late-interaction models—across text, images, audio, and video, depending on the model.
+
+The Sentence Transformers integration was developed with help from the ColPali and ViDoRe teams in bringing the model configurations to the Hugging Face Hub. See the [v6 release](https://github.com/huggingface/sentence-transformers/releases/tag/v6.0.0), the [multi-vector documentation](https://www.sbert.net/docs/multi_vector_encoder/usage/usage.html), and the dedicated [migration guide from `colpali-engine`](https://www.sbert.net/docs/migration_guide.html#migrating-from-colpali-engine).
+
+Install Sentence Transformers with image support:
+
+```bash
+pip install -U "sentence-transformers[image]>=6.0.0"
+```
+
+ColPali-family models now use the same concise API as other late-interaction models:
+
+```python
+from sentence_transformers import MultiVectorEncoder
+
+# You can also use models such as "vidore/colqwen2-v1.0" or "vidore/colpali-v1.3".
+model = MultiVectorEncoder("vidore/colqwen2.5-v0.2")
+
+queries = [
+    "What is the variable represented on the y-axis of the graph?",
+    "Which year has the highest total outlay?",
+]
+images = ["page_1.png", "page_2.png"]  # Paths, URLs, or PIL images
+
+query_embeddings = model.encode_query(queries)
+document_embeddings = model.encode_document(images)
+scores = model.similarity(query_embeddings, document_embeddings)
+```
+
+### Migrating from `colpali-engine`
+
+Sentence Transformers automatically recognizes Transformers-native `*ForRetrieval` checkpoints, including the `-hf` variants of the Vidore models. For example, `vidore/colqwen2-v1.0-hf` keeps its projection and normalization inside the model while its processor formats text queries and image documents.
+
+The main API equivalents are:
+
+| `colpali-engine` | Sentence Transformers v6 |
+|---|---|
+| `ColQwen2.from_pretrained(...)` and `ColQwen2Processor` | `MultiVectorEncoder("vidore/colqwen2-v1.0")` |
+| `processor.process_queries(...)` followed by `model(**batch)` | `model.encode_query(queries)` |
+| `processor.process_images(...)` followed by `model(**batch)` | `model.encode_document(images)` |
+| `processor.score_multi_vector(query_embeddings, document_embeddings)` | `model.similarity(query_embeddings, document_embeddings)` |
+| `mask_non_image_embeddings=True` | `MultiVectorMask(keep_only_token_ids=[processor.tokenizer.convert_tokens_to_ids(processor.image_token)])` |
+| `HierarchicalTokenPooler` | `HierarchicalTokenPooling` |
+| `colpali_engine.interpretability` | `sentence_transformers.multi_vector_encoder.interpretability` |
+
+In short, most inference migrations reduce to:
+
+```python
+from sentence_transformers import MultiVectorEncoder
+
+model = MultiVectorEncoder("vidore/colqwen2-v1.0")
+query_embeddings = model.encode_query(queries)
+document_embeddings = model.encode_document(images)
+scores = model.similarity(query_embeddings, document_embeddings)
+```
+
+For exact-parity notes, training guidance, and advanced configuration, refer to the full [Sentence Transformers migration guide](https://www.sbert.net/docs/migration_guide.html#migrating-from-colpali-engine).
+
+A huge thank you to every user, contributor, and researcher who supported the ColPali project, shared feedback, built integrations, trained models, and believed in visual document retrieval alongside us. We are deeply grateful to everyone who joined us on this journey, which is far from over and continues over at SentenceTransformers. 💛
+
+The original project documentation is preserved below for research and reproducibility.
+
 ## List of ColVision models
 
 | Model                                                               | Score on [ViDoRe](https://huggingface.co/spaces/vidore/vidore-leaderboard) 🏆 | License    | Comments                                                                                                                                                       | Currently supported |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ dataloader = DataLoader(
     collate_fn=lambda x: processor.process_images(x),
 )
 
-ds  = []
+ds = []
 for batch_doc in tqdm(dataloader):
     with torch.no_grad():
         batch_doc = {k: v.to(model.device) for k, v in batch_doc.items()}

--- a/docs/add_model_family.md
+++ b/docs/add_model_family.md
@@ -72,6 +72,7 @@ Expose patch metadata needed by interpretability when the backbone supports it:
 def patch_size(self) -> int:
     return self.visual.config.patch_size
 
+
 @property
 def spatial_merge_size(self) -> int:
     return self.visual.config.spatial_merge_size
@@ -120,8 +121,7 @@ Processors should inherit from `BaseVisualRetrieverProcessor` and the matching
 Transformers processor:
 
 ```python
-class ColNewFamilyProcessor(BaseVisualRetrieverProcessor, NewFamilyProcessor):
-    ...
+class ColNewFamilyProcessor(BaseVisualRetrieverProcessor, NewFamilyProcessor): ...
 ```
 
 The processor must implement:


### PR DESCRIPTION
## Summary

This is part 1/2 of the repository cleanup planned before deprecating ColPali Engine and directing users toward Sentence Transformers.

This PR prepares the final `0.3.18` release by:

- Updating the supported Torch, PEFT, and Pillow dependency ranges for the last time.
- Adding the new optional `[plaid]` extra for Fast-PLAID.
- Bringing the changelog up to date for releases `0.3.15` through `0.3.18`.
- Fixing Ruff formatting issues in the README and model-family documentation.

No deprecation changes are introduced yet. Those will follow separately in part 2/2.

## Important merge note

**Please do not squash the commits in this PR.**

The dependency updates were intentionally kept as individual commits to preserve their history and make the final maintenance changes easy to trace.


## Summary part 2

This is part 2/2 of the repository cleanup before deprecating ColPali Engine.

`colpali-engine` is now deprecated. The repository and package remain available for research, reproducibility, and existing projects, but new projects and production users should migrate to [Sentence Transformers](https://www.sbert.net/).

Sentence Transformers v6 introduces first-class support for ColPali-style models through `MultiVectorEncoder`. It provides a unified ecosystem for dense bi-encoders and multi-vector late-interaction models across text, images, audio, and video, depending on the model.

The ColPali and ViDoRe teams provided some assistance with bringing the model configurations to the Hugging Face Hub.

## Changes

- Add a prominent deprecation notice after the README introduction.
- Direct new and production users to Sentence Transformers v6.
- Explain the unified embedding and retrieval model support.
- Add installation and inference examples using ColPali-family checkpoints.
- Include the `colpali-engine` → Sentence Transformers API migration table.
- Link to the Sentence Transformers v6 release, multi-vector documentation, and complete migration guide.
- Preserve the original ColPali documentation for research and reproducibility.
- Thank the users, contributors, and researchers who supported the project.

## Migration example
```python
from sentence_transformers import MultiVectorEncoder

model = MultiVectorEncoder("vidore/colqwen2-v1.0")

query_embeddings = model.encode_query(queries)
document_embeddings = model.encode_document(images)
scores = model.similarity(query_embeddings, document_embeddings)

## Validation

- `ruff check --fix`
- `ruff format --check`
- `git diff --check`